### PR TITLE
(#1735787) core: never propagate reload failure to service result

### DIFF
--- a/src/core/service.c
+++ b/src/core/service.c
@@ -3310,7 +3310,7 @@ static void service_sigchld_event(Unit *u, pid_t pid, int code, int status) {
                               "Control process exited, code=%s status=%i",
                               sigchld_code_to_string(code), status);
 
-                if (s->result == SERVICE_SUCCESS)
+                if (s->state != SERVICE_RELOAD && s->result == SERVICE_SUCCESS)
                         s->result = f;
 
                 if (s->control_command &&


### PR DESCRIPTION
Fixes: #11238
(cherry picked from commit d611cfa748aaf600832160132774074e808c82c7)

Resolves: #1735787