### PR TITLE
(#1748258) buildsys: don't garbage collect sections while linking

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -357,8 +357,6 @@ if get_option('buildtype') != 'debug'
                 '-ffunction-sections',
                 '-fdata-sections',
         ]
-
-        possible_link_flags += '-Wl,--gc-sections'
 endif
 
 add_project_arguments(cc.get_supported_arguments(possible_cc_flags), language : 'c')


### PR DESCRIPTION
gc-sections is actually very aggressive and garbage collects ELF
sections used by annobin gcc plugin and annocheck then reports gaps in
coverage. Let's drop that linker flag.

RHEL-only

Resolves: #1748258