### PR TITLE
(#1749212) core: try to reopen /dev/kmsg again right after mounting /dev

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2215,6 +2215,11 @@ int main(int argc, char *argv[]) {
                                         goto finish;
                                 }
 
+                                /* Let's open the log backend a second time, in case the first time didn't
+                                 * work. Quite possibly we have mounted /dev just now, so /dev/kmsg became
+                                 * available, and it previously wasn't. */
+                                log_open();
+
                                 r = initialize_security(
                                                 &loaded_policy,
                                                 &security_start_timestamp,


### PR DESCRIPTION
I was debugging stuff during early boot, and was confused that I never
found the logs for it in kmsg. The reason for that was that /proc is
generally not mounted the first time we do log_open() and hence
log_set_target(LOG_TARGET_KMSG) we do when running as PID 1 had not
effect. A lot later during start-up we call log_open() again where this
is fixed (after the point where we close all remaining fds still open),
but in the meantime no logs every got written to kmsg. This patch fixes
that.

(cherry picked from commit 0a2eef1ee1fef74be9d12f7dc4d0006b645b579c)

Resolves: #1749212