### PR TITLE
(#1701454) (#1701454) kernel-install: do not require non-empty kernel cmdline

### DIFF
--- a/src/kernel-install/90-loaderentry.install
+++ b/src/kernel-install/90-loaderentry.install
@@ -43,24 +43,18 @@ if ! [[ $PRETTY_NAME ]]; then
     PRETTY_NAME="Linux $KERNEL_VERSION"
 fi
 
-declare -a BOOT_OPTIONS
-
 if [[ -f /etc/kernel/cmdline ]]; then
     read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
-fi
+elif [[ -f /usr/lib/kernel/cmdline ]]; then
+    read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
+else
+    declare -a BOOT_OPTIONS
 
-if ! [[ ${BOOT_OPTIONS[*]} ]]; then
     read -r -d '' -a line < /proc/cmdline
     for i in "${line[@]}"; do
         [[ "${i#initrd=*}" != "$i" ]] && continue
         BOOT_OPTIONS+=("$i")
     done
-fi
-
-if ! [[ ${BOOT_OPTIONS[*]} ]]; then
-    echo "Could not determine the kernel command line parameters." >&2
-    echo "Please specify the kernel command line in /etc/kernel/cmdline!" >&2
-    exit 1
 fi
 
 cp "$KERNEL_IMAGE" "$BOOT_DIR_ABS/linux" &&


### PR DESCRIPTION
When booting with Fedora-Server-dvd-x86_64-30-20190411.n.0.iso,
/proc/cmdline is empty (libvirt, qemu host with bios, not sure if that
matters), after installation to disk, anaconda would "crash" in kernel-core
%posttrans, after calling kernel-install, because dracut would fail
with

> Could not determine the kernel command line parameters.
> Please specify the kernel command line in /etc/kernel/cmdline!

I guess it's legitimate, even if unusual, to have no cmdline parameters.
Two changes are done in this patch:

1. do not fail if the cmdline is empty.
2. if /usr/lib/kernel/cmdline or /etc/kernel/cmdline are present, but
   empty, ignore /proc/cmdline. If there's explicit configuration to
   have empty cmdline, don't ignore it.

The same change was done in dracut:
https://github.com/dracutdevs/dracut/pull/561.

(cherry picked from commit 88e1306af6380794842fb31108ba67895799fab4)

Resolves: #1701454