### PR TITLE
(#1743230) Call getgroups() to know size of supplementary groups array to allocate

### DIFF
--- a/src/basic/user-util.c
+++ b/src/basic/user-util.c
@@ -358,9 +358,8 @@ char* gid_to_name(gid_t gid) {
 }
 
 int in_gid(gid_t gid) {
-        long ngroups_max;
         gid_t *gids;
-        int r, i;
+        int ngroups, r, i;
 
         if (getgid() == gid)
                 return 1;
@@ -371,12 +370,15 @@ int in_gid(gid_t gid) {
         if (!gid_is_valid(gid))
                 return -EINVAL;
 
-        ngroups_max = sysconf(_SC_NGROUPS_MAX);
-        assert(ngroups_max > 0);
+        ngroups = getgroups(0, NULL);
+        if (ngroups < 0)
+                return -errno;
+        if (ngroups == 0)
+                return 0;
 
-        gids = newa(gid_t, ngroups_max);
+        gids = newa(gid_t, ngroups);
 
-        r = getgroups(ngroups_max, gids);
+        r = getgroups(ngroups, gids);
         if (r < 0)
                 return -errno;
 


### PR DESCRIPTION
Resolves RHBZ #1743230 - journalctl dumps core when stack limit is reduced to 256 KB

(cherry picked from commit f5e0b942af1e86993c21f4e5c84342bb10403dac)

Resolves: #1743235