### PR TITLE
(#1757257) Consider smb3 as remote filesystem

### DIFF
--- a/src/basic/mount-util.c
+++ b/src/basic/mount-util.c
@@ -603,6 +603,7 @@ bool fstype_is_network(const char *fstype) {
         return STR_IN_SET(fstype,
                           "afs",
                           "cifs",
+                          "smb3",
                           "smbfs",
                           "sshfs",
                           "ncpfs",


### PR DESCRIPTION
Currently systemd will treat smb3 as local filesystem and cause
can't boot failures. Add smb3 to the list of remote filesystems
to fix this issue.

Signed-off-by: Kenneth D'souza <kdsouza@redhat.com>

(cherry picked from commit ff7d6a740b0c6fa3be63d3908a0858730a0837c5)

Resolves: #1757257