### PR TITLE
(#1717603) basic/user-util: allow dots in user names

### DIFF
--- a/src/basic/user-util.c
+++ b/src/basic/user-util.c
@@ -573,11 +573,14 @@ bool valid_user_group_name(const char *u) {
         /* Checks if the specified name is a valid user/group name. Also see POSIX IEEE Std 1003.1-2008, 2016 Edition,
          * 3.437. We are a bit stricter here however. Specifically we deviate from POSIX rules:
          *
-         * - We don't allow any dots (this would break chown syntax which permits dots as user/group name separator)
          * - We require that names fit into the appropriate utmp field
          * - We don't allow empty user names
          *
          * Note that other systems are even more restrictive, and don't permit underscores or uppercase characters.
+         *
+         * jsynacek: We now allow dots in user names. The checks are not exhaustive as user names like "..." are allowed
+         * and valid according to POSIX, but can't be created using useradd. However, ".user" can be created. Let's not
+         * complicate the code by adding additional checks for weird corner cases like these,  as they don't really matter here.
          */
 
         if (isempty(u))
@@ -585,14 +588,14 @@ bool valid_user_group_name(const char *u) {
 
         if (!(u[0] >= 'a' && u[0] <= 'z') &&
             !(u[0] >= 'A' && u[0] <= 'Z') &&
-            u[0] != '_')
+            u[0] != '_' && u[0] != '.')
                 return false;
 
         for (i = u+1; *i; i++) {
                 if (!(*i >= 'a' && *i <= 'z') &&
                     !(*i >= 'A' && *i <= 'Z') &&
                     !(*i >= '0' && *i <= '9') &&
-                    !IN_SET(*i, '_', '-'))
+                    !IN_SET(*i, '_', '-', '.'))
                         return false;
         }
 

--- a/src/test/test-user-util.c
+++ b/src/test/test-user-util.c
@@ -71,8 +71,6 @@ static void test_valid_user_group_name(void) {
         assert_se(!valid_user_group_name("-1"));
         assert_se(!valid_user_group_name("-kkk"));
         assert_se(!valid_user_group_name("rööt"));
-        assert_se(!valid_user_group_name("."));
-        assert_se(!valid_user_group_name("eff.eff"));
         assert_se(!valid_user_group_name("foo\nbar"));
         assert_se(!valid_user_group_name("0123456789012345678901234567890123456789"));
         assert_se(!valid_user_group_name_or_id("aaa:bbb"));
@@ -83,6 +81,8 @@ static void test_valid_user_group_name(void) {
         assert_se(valid_user_group_name("_kkk"));
         assert_se(valid_user_group_name("kkk-"));
         assert_se(valid_user_group_name("kk-k"));
+        assert_se(valid_user_group_name(".moo"));
+        assert_se(valid_user_group_name("eff.eff"));
 
         assert_se(valid_user_group_name("some5"));
         assert_se(!valid_user_group_name("5some"));
@@ -102,8 +102,6 @@ static void test_valid_user_group_name_or_id(void) {
         assert_se(!valid_user_group_name_or_id("-1"));
         assert_se(!valid_user_group_name_or_id("-kkk"));
         assert_se(!valid_user_group_name_or_id("rööt"));
-        assert_se(!valid_user_group_name_or_id("."));
-        assert_se(!valid_user_group_name_or_id("eff.eff"));
         assert_se(!valid_user_group_name_or_id("foo\nbar"));
         assert_se(!valid_user_group_name_or_id("0123456789012345678901234567890123456789"));
         assert_se(!valid_user_group_name_or_id("aaa:bbb"));
@@ -114,6 +112,8 @@ static void test_valid_user_group_name_or_id(void) {
         assert_se(valid_user_group_name_or_id("_kkk"));
         assert_se(valid_user_group_name_or_id("kkk-"));
         assert_se(valid_user_group_name_or_id("kk-k"));
+        assert_se(valid_user_group_name_or_id(".moo"));
+        assert_se(valid_user_group_name_or_id("eff.eff"));
 
         assert_se(valid_user_group_name_or_id("some5"));
         assert_se(!valid_user_group_name_or_id("5some"));


### PR DESCRIPTION
(based on commit 1a29610f5fa1bcb2eeb37d2c6b79d8d1a6dbb865)

Resolves: #1717603