### PR TITLE
(#1761519) travis: move to CentOS 8 docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,42 +9,40 @@ env:
 
 jobs:
     include:
-        - name: CentOS 7
+        - name: CentOS 8
           language: bash
           env:
-              - CENTOS_RELEASE="centos7"
+              - CENTOS_RELEASE="centos8"
               - CONT_NAME="systemd-centos-$CENTOS_RELEASE"
               - DOCKER_EXEC="docker exec -ti $CONT_NAME"
           before_install:
               - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
               - docker --version
           install:
-              - if [ -f meson.build ]; then RHEL_VERSION=rhel8; else RHEL_VERSION=rhel7; fi
-              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh SETUP
+              - $CI_ROOT/travis-centos-rhel8.sh SETUP
           script:
               - set -e
               # Build systemd
-              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh RUN
+              - $CI_ROOT/travis-centos-rhel8.sh RUN
               - set +e
           after_script:
-              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh CLEANUP
+              - $CI_ROOT/travis-centos-rhel8.sh CLEANUP
 
-        - name: CentOS 7 (ASan+UBSan)
+        - name: CentOS 8 (ASan+UBSan)
           language: bash
           env:
-              - CENTOS_RELEASE="centos7"
+              - CENTOS_RELEASE="centos8"
               - CONT_NAME="systemd-centos-$CENTOS_RELEASE"
               - DOCKER_EXEC="docker exec -ti $CONT_NAME"
           before_install:
               - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
               - docker --version
           install:
-              - if [ -f meson.build ]; then RHEL_VERSION=rhel8; else RHEL_VERSION=rhel7; fi
-              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh SETUP
+              - $CI_ROOT/travis-centos-rhel8.sh SETUP
           script:
               - set -e
               # Build systemd
-              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh RUN_ASAN
+              - $CI_ROOT/travis-centos-rhel8.sh RUN_ASAN
               - set +e
           after_script:
-              - $CI_ROOT/travis-centos-${RHEL_VERSION}.sh CLEANUP
+              - $CI_ROOT/travis-centos-rhel8.sh CLEANUP

--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -113,22 +113,12 @@ for phase in "${PHASES[@]}"; do
             $DOCKER_EXEC ninja -C build test
             ;;
         RUN_ASAN|RUN_CLANG_ASAN)
-            # Note to my future frustrated self: docker exec runs the given command
-            # as sh -c 'command' - which means both .bash_profile and .bashrc will
-            # be ignored. That's because .bash_profile is sourced for LOGIN shells (i.e.
-            # sh -l), whereas .bashrc is sourced for NON-LOGIN INTERACTIVE shells
-            # (i.e. sh -i).
-            # As the default docker exec command lacks either of those options,
-            # we need to use a wrapper command which runs the wanted command
-            # under an explicit bash -i, so the SCL source above works properly.
-            docker exec -it $CONT_NAME bash -ic 'gcc --version'
-
             if [[ "$phase" = "RUN_CLANG_ASAN" ]]; then
                 ENV_VARS="-e CC=clang -e CXX=clang++"
                 MESON_ARGS="-Db_lundef=false" # See https://github.com/mesonbuild/meson/issues/764
             fi
-            docker exec $ENV_VARS -it $CONT_NAME bash -ic "meson build --werror -Dtests=unsafe -Db_sanitize=address,undefined $MESON_ARGS ${CONFIGURE_OPTS[@]}"
-            docker exec -it $CONT_NAME bash -ic 'ninja -v -C build'
+            docker exec $ENV_VARS -it $CONT_NAME meson build --werror -Dtests=unsafe -Db_sanitize=address,undefined $MESON_ARGS ${CONFIGURE_OPTS[@]}
+            docker exec -it $CONT_NAME ninja -v -C build
 
             # Never remove halt_on_error from UBSAN_OPTIONS. See https://github.com/systemd/systemd/commit/2614d83aa06592aedb.
             travis_wait docker exec --interactive=false \
@@ -136,7 +126,7 @@ for phase in "${PHASES[@]}"; do
                 -e ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1 \
                 -e "TRAVIS=$TRAVIS" \
                 -t $CONT_NAME \
-                bash -ic 'meson test --timeout-multiplier=3 -C ./build/ --print-errorlogs'
+                meson test --timeout-multiplier=3 -C ./build/ --print-errorlogs
             ;;
         CLEANUP)
             info "Cleanup phase"

--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -15,10 +15,7 @@ CONT_NAME="${CONT_NAME:-centos-$CENTOS_RELEASE-$RANDOM}"
 DOCKER_EXEC="${DOCKER_EXEC:-docker exec -it $CONT_NAME}"
 DOCKER_RUN="${DOCKER_RUN:-docker run}"
 REPO_ROOT="${REPO_ROOT:-$PWD}"
-ADDITIONAL_DEPS=(systemd-ci-environment libidn2-devel python-lxml python36 ninja-build libasan net-tools strace nc busybox e2fsprogs quota dnsmasq)
-# Repo with additional depencencies to compile newer systemd on CentOS 7
-COPR_REPO="https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci/repo/epel-7/mrc0mmand-systemd-centos-ci-epel-7.repo"
-COPR_REPO_PATH="/etc/yum.repos.d/${COPR_REPO##*/}"
+ADDITIONAL_DEPS=(libasan libubsan net-tools strace nc e2fsprogs quota dnsmasq)
 # RHEL8 options
 CONFIGURE_OPTS=(
     -Dsysvinit-path=/etc/rc.d/init.d
@@ -95,18 +92,14 @@ for phase in "${PHASES[@]}"; do
                         -dit --net=host centos:$CENTOS_RELEASE /sbin/init
             # Beautiful workaround for Fedora's version of Docker
             sleep 1
-            $DOCKER_EXEC yum makecache
-            $DOCKER_EXEC curl "$COPR_REPO" -o "$COPR_REPO_PATH"
-            $DOCKER_EXEC yum -q -y install epel-release yum-utils
-            $DOCKER_EXEC yum-config-manager -q --enable epel
-            $DOCKER_EXEC yum -y upgrade
-            # Install necessary build/test requirements
-            $DOCKER_EXEC yum -y install "${ADDITIONAL_DEPS[@]}"
-            $DOCKER_EXEC python3.6 -m ensurepip
-            $DOCKER_EXEC python3.6 -m pip install meson
-            # Create necessary symlinks
-            $DOCKER_EXEC ln --force -s /usr/bin/python3.6 /usr/bin/python3
-            $DOCKER_EXEC ln --force -s /usr/bin/ninja-build /usr/bin/ninja
+            $DOCKER_EXEC dnf makecache
+            # Install and enable EPEL
+            $DOCKER_EXEC dnf -q -y install epel-release dnf-utils "${ADDITIONAL_DEPS[@]}"
+            $DOCKER_EXEC dnf config-manager -q --enable epel
+            # Upgrade the container to get the most recent environment
+            $DOCKER_EXEC dnf -y upgrade
+            # Install systemd's build dependencies
+            $DOCKER_EXEC dnf -q -y --enablerepo "PowerTools" builddep systemd
             ;;
         RUN)
             info "Run phase"
@@ -117,16 +110,9 @@ for phase in "${PHASES[@]}"; do
             # unexpected fails due to incompatibilities with older systemd
             $DOCKER_EXEC ninja -C build install
             docker restart $CONT_NAME
-            # "Mask" the udev-test.pl, as it requires newer version of systemd-detect-virt
-            # and it's pointless to run it on a VM in a Docker container...
-            echo -ne "#!/usr/bin/perl\nexit(0);\n" > "test/udev-test.pl"
             $DOCKER_EXEC ninja -C build test
             ;;
         RUN_ASAN|RUN_CLANG_ASAN)
-            # Let's install newer gcc for proper ASan/UBSan support
-            $DOCKER_EXEC yum -y install centos-release-scl
-            $DOCKER_EXEC yum -y install devtoolset-8 devtoolset-8-libasan-devel libasan5 devtoolset-8-libubsan-devel libubsan1
-            $DOCKER_EXEC bash -c "echo 'source scl_source enable devtoolset-8' >> /root/.bashrc"
             # Note to my future frustrated self: docker exec runs the given command
             # as sh -c 'command' - which means both .bash_profile and .bashrc will
             # be ignored. That's because .bash_profile is sourced for LOGIN shells (i.e.

--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -65,10 +65,6 @@ CONFIGURE_OPTS=(
     -Dnetworkd=false
     -Dtimesyncd=false
     -Ddefault-hierarchy=legacy
-    # Custom options
-    -Dslow-tests=true
-    -Dtests=unsafe
-    -Dinstall-tests=true
 )
 
 function info() {
@@ -104,7 +100,7 @@ for phase in "${PHASES[@]}"; do
         RUN)
             info "Run phase"
             # Build systemd
-            docker exec -it -e CFLAGS='-g -O0 -ftrapv' $CONT_NAME meson build "${CONFIGURE_OPTS[@]}"
+            docker exec -it -e CFLAGS='-g -O0 -ftrapv' $CONT_NAME meson build -Dtests=unsafe -Dslow-tests=true "${CONFIGURE_OPTS[@]}"
             $DOCKER_EXEC ninja -v -C build
             # Let's install the new systemd and "reboot" the container to avoid
             # unexpected fails due to incompatibilities with older systemd
@@ -117,7 +113,7 @@ for phase in "${PHASES[@]}"; do
                 ENV_VARS="-e CC=clang -e CXX=clang++"
                 MESON_ARGS="-Db_lundef=false" # See https://github.com/mesonbuild/meson/issues/764
             fi
-            docker exec $ENV_VARS -it $CONT_NAME meson build --werror -Dtests=unsafe -Db_sanitize=address,undefined $MESON_ARGS ${CONFIGURE_OPTS[@]}
+            docker exec $ENV_VARS -it $CONT_NAME meson build --werror -Dtests=unsafe -Db_sanitize=address,undefined $MESON_ARGS "${CONFIGURE_OPTS[@]}"
             docker exec -it $CONT_NAME ninja -v -C build
 
             # Never remove halt_on_error from UBSAN_OPTIONS. See https://github.com/systemd/systemd/commit/2614d83aa06592aedb.

--- a/src/basic/syslog-util.c
+++ b/src/basic/syslog-util.c
@@ -10,7 +10,8 @@
 
 int syslog_parse_priority(const char **p, int *priority, bool with_facility) {
         int a = 0, b = 0, c = 0;
-        int k;
+        const char *end;
+        size_t k;
 
         assert(p);
         assert(*p);
@@ -19,21 +20,22 @@ int syslog_parse_priority(const char **p, int *priority, bool with_facility) {
         if ((*p)[0] != '<')
                 return 0;
 
-        if (!strchr(*p, '>'))
+        end = strchr(*p, '>');
+        if (!end)
                 return 0;
 
-        if ((*p)[2] == '>') {
+        k = end - *p;
+        assert(k > 0);
+
+        if (k == 2)
                 c = undecchar((*p)[1]);
-                k = 3;
-        } else if ((*p)[3] == '>') {
+        else if (k == 3) {
                 b = undecchar((*p)[1]);
                 c = undecchar((*p)[2]);
-                k = 4;
-        } else if ((*p)[4] == '>') {
+        } else if (k == 4) {
                 a = undecchar((*p)[1]);
                 b = undecchar((*p)[2]);
                 c = undecchar((*p)[3]);
-                k = 5;
         } else
                 return 0;
 
@@ -46,7 +48,7 @@ int syslog_parse_priority(const char **p, int *priority, bool with_facility) {
         else
                 *priority = (*priority & LOG_FACMASK) | c;
 
-        *p += k;
+        *p += k + 1;
         return 1;
 }
 

--- a/src/journal/test-journal-syslog.c
+++ b/src/journal/test-journal-syslog.c
@@ -4,6 +4,7 @@
 #include "journald-syslog.h"
 #include "macro.h"
 #include "string-util.h"
+#include "syslog-util.h"
 
 static void test_syslog_parse_identifier(const char *str,
                                          const char *ident, const char *pid, const char *rest, int ret) {
@@ -19,6 +20,17 @@ static void test_syslog_parse_identifier(const char *str,
         assert_se(streq(buf, rest));
 }
 
+static void test_syslog_parse_priority(const char *str, int priority, int ret) {
+        const char *buf = str;
+        int priority2, ret2;
+
+        ret2 = syslog_parse_priority(&buf, &priority2, false);
+
+        assert_se(ret == ret2);
+        if (ret2 == 1)
+                assert_se(priority == priority2);
+}
+
 int main(void) {
         test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", "xxx", 11);
         test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, "xxx", 6);
@@ -32,6 +44,14 @@ int main(void) {
         test_syslog_parse_identifier("pidu:", "pidu", NULL, "", 5);
         test_syslog_parse_identifier("pidu: ", "pidu", NULL, "", 6);
         test_syslog_parse_identifier("pidu : ", NULL, NULL, "pidu : ", 0);
+
+        test_syslog_parse_priority("<>", 0, 0);
+        test_syslog_parse_priority("<>aaa", 0, 0);
+        test_syslog_parse_priority("<aaaa>", 0, 0);
+        test_syslog_parse_priority("<aaaa>aaa", 0, 0);
+        test_syslog_parse_priority(" <aaaa>", 0, 0);
+        test_syslog_parse_priority(" <aaaa>aaa", 0, 0);
+        /* TODO: add test cases of valid priorities */
 
         return 0;
 }

--- a/src/libsystemd/sd-bus/bus-message.c
+++ b/src/libsystemd/sd-bus/bus-message.c
@@ -5101,6 +5101,7 @@ int bus_message_parse_fields(sd_bus_message *m) {
                                 return -EBADMSG;
 
                         if (*p == 0) {
+                                char *k;
                                 size_t l;
 
                                 /* We found the beginning of the signature
@@ -5114,9 +5115,11 @@ int bus_message_parse_fields(sd_bus_message *m) {
                                     p[1 + l - 1] != SD_BUS_TYPE_STRUCT_END)
                                         return -EBADMSG;
 
-                                if (free_and_strndup(&m->root_container.signature,
-                                                     p + 1 + 1, l - 2) < 0)
+                                k = memdup_suffix0(p + 1 + 1, l - 2);
+                                if (!k)
                                         return -ENOMEM;
+
+                                free_and_replace(m->root_container.signature, k);
                                 break;
                         }
 


### PR DESCRIPTION
As the CentOS 8 Docker images is finally out, we can use it and drop the
plethora of workarounds we had to implement to compile RHEL8 systemd on
CentOS 7.

---

I'll create a BZ and link it to the commit(s) once everything works as expected.