### PR TITLE
(#1762679) udev: introduce CONST key name

### DIFF
--- a/man/udev.xml
+++ b/man/udev.xml
@@ -237,6 +237,32 @@
         </varlistentry>
 
         <varlistentry>
+          <term><varname>CONST{<replaceable>key</replaceable>}</varname></term>
+          <listitem>
+            <para>Match against a system-wide constant. Supported keys are:</para>
+            <variablelist>
+              <varlistentry>
+                <term><literal>arch</literal></term>
+                <listitem>
+                  <para>System's architecture. See <option>ConditionArchitecture=</option> in
+                  <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+                  for possible values.</para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term><literal>virt</literal></term>
+                <listitem>
+                  <para>System's virtualization environment. See
+                  <citerefentry><refentrytitle>systemd-detect-virt</refentrytitle><manvolnum>1</manvolnum></citerefentry>
+                  for possible values.</para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+            <para>Unknown keys will never match.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term><varname>TAG</varname></term>
           <listitem>
             <para>Match against a device tag.</para>

--- a/rules/40-redhat.rules
+++ b/rules/40-redhat.rules
@@ -6,11 +6,11 @@ SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}
 # Memory hotadd request
 SUBSYSTEM!="memory", GOTO="memory_hotplug_end"
 ACTION!="add", GOTO="memory_hotplug_end"
-PROGRAM="/bin/uname -p", RESULT=="s390*", GOTO="memory_hotplug_end"
-PROGRAM="/bin/uname -p", RESULT=="ppc64*", GOTO="memory_hotplug_end"
+CONST{arch}=="s390*", GOTO="memory_hotplug_end"
+CONST{arch}=="ppc64*", GOTO="memory_hotplug_end"
 
 ENV{.state}="online"
-PROGRAM="/bin/systemd-detect-virt", RESULT=="none", ENV{.state}="online_movable"
+CONST{virt}=="none", ENV{.state}="online_movable"
 ATTR{state}=="offline", ATTR{state}="$env{.state}"
 
 LABEL="memory_hotplug_end"

--- a/test/rule-syntax-check.py
+++ b/test/rule-syntax-check.py
@@ -19,7 +19,7 @@ quoted_string_re = r'"(?:[^\\"]|\\.)*"'
 no_args_tests = re.compile(r'(ACTION|DEVPATH|KERNELS?|NAME|SYMLINK|SUBSYSTEMS?|DRIVERS?|TAG|PROGRAM|RESULT|TEST)\s*(?:=|!)=\s*' + quoted_string_re + '$')
 # PROGRAM can also be specified as an assignment.
 program_assign = re.compile(r'PROGRAM\s*=\s*' + quoted_string_re + '$')
-args_tests = re.compile(r'(ATTRS?|ENV|TEST){([a-zA-Z0-9/_.*%-]+)}\s*(?:=|!)=\s*' + quoted_string_re + '$')
+args_tests = re.compile(r'(ATTRS?|ENV|CONST|TEST){([a-zA-Z0-9/_.*%-]+)}\s*(?:=|!)=\s*' + quoted_string_re + '$')
 no_args_assign = re.compile(r'(NAME|SYMLINK|OWNER|GROUP|MODE|TAG|RUN|LABEL|GOTO|WAIT_FOR|OPTIONS|IMPORT)\s*(?:\+=|:=|=)\s*' + quoted_string_re + '$')
 args_assign = re.compile(r'(ATTR|ENV|IMPORT|RUN){([a-zA-Z0-9/_.*%-]+)}\s*(=|\+=)\s*' + quoted_string_re + '$')
 # Find comma-separated groups, but allow commas that are inside quoted strings.


### PR DESCRIPTION
Currently, there is no way to match against system-wide constants, such
as architecture or virtualization type, without forking helper binaries.
That potentially results in a huge number of spawned processes which
output always the same answer.

This patch introduces a special CONST keyword which takes a hard-coded
string as its key and returns a value assigned to that key. Currently
implemented are CONST{arch} and CONST{virt}, which can be used to match
against the system's architecture and virtualization type.

(based on commit 4801d8afe2ff1c1c075c9f0bc5631612172e0bb7)

Resolves: #1762679

This patch also includes https://github.com/systemd/systemd/pull/13790, which I forgot to add to the original upstream PR.