### PR TITLE
(#1777037) ask-password: prevent buffer overrow when reading from keyring

### DIFF
--- a/src/shared/ask-password-api.c
+++ b/src/shared/ask-password-api.c
@@ -79,7 +79,7 @@ static int retrieve_key(key_serial_t serial, char ***ret) {
                 if (n < m)
                         break;
 
-                explicit_bzero(p, n);
+                explicit_bzero(p, m);
                 free(p);
                 m *= 2;
         }


### PR DESCRIPTION
When we read from keyring, a temporary buffer is allocated in order to
determine the size needed for the entire data. However, when zeroing that area,
we use the data size returned by the read instead of the lesser size allocate
for the buffer.

That will cause memory corruption that causes systemd-cryptsetup to crash
either when a single large password is used or when multiple passwords have
already been pushed to the keyring.

Signed-off-by: Thadeu Lima de Souza Cascardo <cascardo@canonical.com>
(cherry picked from commit 59c55e73eaee345e1ee67c23eace8895ed499693)
(cherry picked from commit c6c8e0d097d6ba12471c6112c3fd339ea40329d5)

Resolves: #1777037