### PR TITLE
(#1696602) cryptsetup: reduce the chance that we will be OOM killed

### DIFF
--- a/src/cryptsetup/cryptsetup.c
+++ b/src/cryptsetup/cryptsetup.c
@@ -656,6 +656,12 @@ int main(int argc, char *argv[]) {
                 if (arg_discards)
                         flags |= CRYPT_ACTIVATE_ALLOW_DISCARDS;
 
+#ifdef CRYPT_ACTIVATE_SERIALIZE_MEMORY_HARD_PBKDF
+                /* Try to decrease the risk of OOM event if memory hard key derivation function is in use */
+                /* https://gitlab.com/cryptsetup/cryptsetup/issues/446/ */
+                flags |= CRYPT_ACTIVATE_SERIALIZE_MEMORY_HARD_PBKDF;
+#endif
+
                 if (arg_timeout == USEC_INFINITY)
                         until = 0;
                 else


### PR DESCRIPTION
cryptsetup introduced optional locking scheme that should serialize
unlocking keyslots which use memory hard key derivation
function (argon2). Using the serialization should prevent OOM situation
in early boot while unlocking encrypted volumes.

(cherry picked from commit 408c81f62454684dfbff1c95ce3210d06f256e58)

Resolves: #1696602