### PR TITLE
(#1781712) core, job: fix breakage of ordering dependencies by systemctl reload …

### DIFF
--- a/src/basic/syslog-util.c
+++ b/src/basic/syslog-util.c
@@ -10,7 +10,8 @@
 
 int syslog_parse_priority(const char **p, int *priority, bool with_facility) {
         int a = 0, b = 0, c = 0;
-        int k;
+        const char *end;
+        size_t k;
 
         assert(p);
         assert(*p);
@@ -19,21 +20,22 @@ int syslog_parse_priority(const char **p, int *priority, bool with_facility) {
         if ((*p)[0] != '<')
                 return 0;
 
-        if (!strchr(*p, '>'))
+        end = strchr(*p, '>');
+        if (!end)
                 return 0;
 
-        if ((*p)[2] == '>') {
+        k = end - *p;
+        assert(k > 0);
+
+        if (k == 2)
                 c = undecchar((*p)[1]);
-                k = 3;
-        } else if ((*p)[3] == '>') {
+        else if (k == 3) {
                 b = undecchar((*p)[1]);
                 c = undecchar((*p)[2]);
-                k = 4;
-        } else if ((*p)[4] == '>') {
+        } else if (k == 4) {
                 a = undecchar((*p)[1]);
                 b = undecchar((*p)[2]);
                 c = undecchar((*p)[3]);
-                k = 5;
         } else
                 return 0;
 
@@ -46,7 +48,7 @@ int syslog_parse_priority(const char **p, int *priority, bool with_facility) {
         else
                 *priority = (*priority & LOG_FACMASK) | c;
 
-        *p += k;
+        *p += k + 1;
         return 1;
 }
 

--- a/src/core/job.c
+++ b/src/core/job.c
@@ -403,21 +403,21 @@ JobType job_type_collapse(JobType t, Unit *u) {
 
         case JOB_TRY_RESTART:
                 s = unit_active_state(u);
-                if (UNIT_IS_INACTIVE_OR_DEACTIVATING(s))
+                if (!UNIT_IS_ACTIVE_OR_RELOADING(s))
                         return JOB_NOP;
 
                 return JOB_RESTART;
 
         case JOB_TRY_RELOAD:
                 s = unit_active_state(u);
-                if (UNIT_IS_INACTIVE_OR_DEACTIVATING(s))
+                if (!UNIT_IS_ACTIVE_OR_RELOADING(s))
                         return JOB_NOP;
 
                 return JOB_RELOAD;
 
         case JOB_RELOAD_OR_START:
                 s = unit_active_state(u);
-                if (UNIT_IS_INACTIVE_OR_DEACTIVATING(s))
+                if (!UNIT_IS_ACTIVE_OR_RELOADING(s))
                         return JOB_START;
 
                 return JOB_RELOAD;

--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -1041,7 +1041,8 @@ int server_flush_to_var(Server *s, bool require_flag_file) {
         r = 0;
 
 finish:
-        journal_file_post_change(s->system_journal);
+        if (s->system_journal)
+                journal_file_post_change(s->system_journal);
 
         s->runtime_journal = journal_file_close(s->runtime_journal);
 

--- a/src/journal/test-journal-syslog.c
+++ b/src/journal/test-journal-syslog.c
@@ -4,6 +4,7 @@
 #include "journald-syslog.h"
 #include "macro.h"
 #include "string-util.h"
+#include "syslog-util.h"
 
 static void test_syslog_parse_identifier(const char *str,
                                          const char *ident, const char *pid, const char *rest, int ret) {
@@ -19,6 +20,17 @@ static void test_syslog_parse_identifier(const char *str,
         assert_se(streq(buf, rest));
 }
 
+static void test_syslog_parse_priority(const char *str, int priority, int ret) {
+        const char *buf = str;
+        int priority2, ret2;
+
+        ret2 = syslog_parse_priority(&buf, &priority2, false);
+
+        assert_se(ret == ret2);
+        if (ret2 == 1)
+                assert_se(priority == priority2);
+}
+
 int main(void) {
         test_syslog_parse_identifier("pidu[111]: xxx", "pidu", "111", "xxx", 11);
         test_syslog_parse_identifier("pidu: xxx", "pidu", NULL, "xxx", 6);
@@ -32,6 +44,14 @@ int main(void) {
         test_syslog_parse_identifier("pidu:", "pidu", NULL, "", 5);
         test_syslog_parse_identifier("pidu: ", "pidu", NULL, "", 6);
         test_syslog_parse_identifier("pidu : ", NULL, NULL, "pidu : ", 0);
+
+        test_syslog_parse_priority("<>", 0, 0);
+        test_syslog_parse_priority("<>aaa", 0, 0);
+        test_syslog_parse_priority("<aaaa>", 0, 0);
+        test_syslog_parse_priority("<aaaa>aaa", 0, 0);
+        test_syslog_parse_priority(" <aaaa>", 0, 0);
+        test_syslog_parse_priority(" <aaaa>aaa", 0, 0);
+        /* TODO: add test cases of valid priorities */
 
         return 0;
 }

--- a/test/TEST-02-CRYPTSETUP/test.sh
+++ b/test/TEST-02-CRYPTSETUP/test.sh
@@ -45,6 +45,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-02-CRYPTSETUP/test.sh
+++ b/test/TEST-02-CRYPTSETUP/test.sh
@@ -29,7 +29,7 @@ check_result_qemu() {
 test_setup() {
     create_empty_image
     echo -n test >$TESTDIR/keyfile
-    cryptsetup -q luksFormat ${LOOPDEV}p2 $TESTDIR/keyfile
+    cryptsetup -q luksFormat --pbkdf pbkdf2 --pbkdf-force-iterations 1000 ${LOOPDEV}p2 $TESTDIR/keyfile
     cryptsetup luksOpen ${LOOPDEV}p2 varcrypt <$TESTDIR/keyfile
     mkfs.ext4 -L var /dev/mapper/varcrypt
     mkdir -p $TESTDIR/root

--- a/test/TEST-03-JOBS/test.sh
+++ b/test/TEST-03-JOBS/test.sh
@@ -19,6 +19,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-04-JOURNAL/test.sh
+++ b/test/TEST-04-JOURNAL/test.sh
@@ -18,6 +18,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-05-RLIMITS/test.sh
+++ b/test/TEST-05-RLIMITS/test.sh
@@ -18,6 +18,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         cat >$initdir/etc/systemd/system.conf <<EOF
 [Manager]
 DefaultLimitNOFILE=10000:16384

--- a/test/TEST-07-ISSUE-1981/test.sh
+++ b/test/TEST-07-ISSUE-1981/test.sh
@@ -21,6 +21,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-11-ISSUE-3166/test.sh
+++ b/test/TEST-11-ISSUE-3166/test.sh
@@ -20,6 +20,14 @@ test_setup() {
         setup_basic_environment
         dracut_install false touch
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-12-ISSUE-3171/test.sh
+++ b/test/TEST-12-ISSUE-3171/test.sh
@@ -20,6 +20,14 @@ test_setup() {
         setup_basic_environment
         dracut_install cat mv stat nc
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-13-NSPAWN-SMOKE/test.sh
+++ b/test/TEST-13-NSPAWN-SMOKE/test.sh
@@ -20,6 +20,14 @@ test_setup() {
         setup_basic_environment
         dracut_install busybox chmod rmdir unshare ip sysctl
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         cp create-busybox-container $initdir/
 
         ./create-busybox-container $initdir/nc-container

--- a/test/TEST-18-FAILUREACTION/test.sh
+++ b/test/TEST-18-FAILUREACTION/test.sh
@@ -35,6 +35,13 @@ EOF
     ) || return 1
     setup_nspawn_root
 
+    # mask some services that we do not want to run in these tests
+    ln -s /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+    ln -s /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+    ln -s /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+    ln -s /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+    ln -s /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+
     ddebug "umount $TESTDIR/root"
     umount $TESTDIR/root
 }

--- a/test/TEST-19-DELEGATE/test.sh
+++ b/test/TEST-19-DELEGATE/test.sh
@@ -20,6 +20,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-20-MAINPIDGAMES/test.sh
+++ b/test/TEST-20-MAINPIDGAMES/test.sh
@@ -17,6 +17,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/TEST-23-TYPE-EXEC/test.sh
+++ b/test/TEST-23-TYPE-EXEC/test.sh
@@ -17,6 +17,14 @@ test_setup() {
 
         setup_basic_environment
 
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-hwdb-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-journal-catalog-update.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-networkd.socket
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-resolved.service
+        ln -fs /dev/null $initdir/etc/systemd/system/systemd-machined.service
+
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF
 [Unit]

--- a/test/test-functions
+++ b/test/test-functions
@@ -433,7 +433,7 @@ create_empty_image() {
     [ -b "$LOOPDEV" ] || return 1
     echo "LOOPDEV=$LOOPDEV" >> $STATEFILE
     sfdisk "$LOOPDEV" <<EOF
-,390M
+,350M
 ,
 EOF
 


### PR DESCRIPTION
…command

Currently, systemctl reload command breaks ordering dependencies if it's
executed when its target service unit is in activating state.

For example, prepare A.service, B.service and C.target as follows:

    # systemctl cat A.service B.service C.target
    # /etc/systemd/system/A.service
    [Unit]
    Description=A

    [Service]
    Type=oneshot
    ExecStart=/usr/bin/echo A1
    ExecStart=/usr/bin/sleep 60
    ExecStart=/usr/bin/echo A2
    ExecReload=/usr/bin/echo A reloaded
    RemainAfterExit=yes

    # /etc/systemd/system/B.service
    [Unit]
    Description=B
    After=A.service

    [Service]
    Type=oneshot
    ExecStart=/usr/bin/echo B
    RemainAfterExit=yes

    # /etc/systemd/system/C.target
    [Unit]
    Description=C
    Wants=A.service B.service

Start them.

    # systemctl daemon-reload
    # systemctl start C.target

Then, we have:

    # LANG=C journalctl --no-pager -u A.service -u B.service -u C.target -b
    -- Logs begin at Mon 2019-09-09 00:25:06 EDT, end at Thu 2019-10-24 22:28:47 EDT. --
    Oct 24 22:27:47 localhost.localdomain systemd[1]: Starting A...
    Oct 24 22:27:47 localhost.localdomain systemd[1]: A.service: Child 967 belongs to A.service.
    Oct 24 22:27:47 localhost.localdomain systemd[1]: A.service: Main process exited, code=exited, status=0/SUCCESS
    Oct 24 22:27:47 localhost.localdomain systemd[1]: A.service: Running next main command for state start.
    Oct 24 22:27:47 localhost.localdomain systemd[1]: A.service: Passing 0 fds to service
    Oct 24 22:27:47 localhost.localdomain systemd[1]: A.service: About to execute: /usr/bin/sleep 60
    Oct 24 22:27:47 localhost.localdomain systemd[1]: A.service: Forked /usr/bin/sleep as 968
    Oct 24 22:27:47 localhost.localdomain systemd[968]: A.service: Executing: /usr/bin/sleep 60
    Oct 24 22:27:52 localhost.localdomain systemd[1]: A.service: Trying to enqueue job A.service/reload/replace
    Oct 24 22:27:52 localhost.localdomain systemd[1]: A.service: Merged into running job, re-running: A.service/reload as 1288
    Oct 24 22:27:52 localhost.localdomain systemd[1]: A.service: Enqueued job A.service/reload as 1288
    Oct 24 22:27:52 localhost.localdomain systemd[1]: A.service: Unit cannot be reloaded because it is inactive.
    Oct 24 22:27:52 localhost.localdomain systemd[1]: A.service: Job 1288 A.service/reload finished, result=invalid
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Passing 0 fds to service
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: About to execute: /usr/bin/echo B
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Forked /usr/bin/echo as 970
    Oct 24 22:27:52 localhost.localdomain systemd[970]: B.service: Executing: /usr/bin/echo B
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Failed to send unit change signal for B.service: Connection reset by peer
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Changed dead -> start
    Oct 24 22:27:52 localhost.localdomain systemd[1]: Starting B...
    Oct 24 22:27:52 localhost.localdomain echo[970]: B
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Child 970 belongs to B.service.
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Main process exited, code=exited, status=0/SUCCESS
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Changed start -> exited
    Oct 24 22:27:52 localhost.localdomain systemd[1]: B.service: Job 1371 B.service/start finished, result=done
    Oct 24 22:27:52 localhost.localdomain systemd[1]: Started B.
    Oct 24 22:27:52 localhost.localdomain systemd[1]: C.target: Job 1287 C.target/start finished, result=done
    Oct 24 22:27:52 localhost.localdomain systemd[1]: Reached target C.
    Oct 24 22:27:52 localhost.localdomain systemd[1]: C.target: Failed to send unit change signal for C.target: Connection reset by peer
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Child 968 belongs to A.service.
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Main process exited, code=exited, status=0/SUCCESS
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Running next main command for state start.
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Passing 0 fds to service
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: About to execute: /usr/bin/echo A2
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Forked /usr/bin/echo as 972
    Oct 24 22:28:47 localhost.localdomain systemd[972]: A.service: Executing: /usr/bin/echo A2
    Oct 24 22:28:47 localhost.localdomain echo[972]: A2
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Child 972 belongs to A.service.
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Main process exited, code=exited, status=0/SUCCESS
    Oct 24 22:28:47 localhost.localdomain systemd[1]: A.service: Changed start -> exited

The issue occurs not only in reload command, i.e.:

  - reload
  - try-restart
  - reload-or-restart
  - reload-or-try-restart commands

The cause of this issue is that job_type_collapse() doesn't take care of the
activating state.

Fixes: #10464
(cherry picked from commit d1559793df555212271e490a4a72f55826caf5b4)
(cherry picked from commit cb084637ba1c8558f1538ce300c5520a6764dc76)
Resolves: #1781712