### PR TITLE
(#1809037) pid1: fix DefaultTasksMax initialization

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2088,7 +2088,7 @@ static void reset_arguments(void) {
         arg_default_blockio_accounting = false;
         arg_default_memory_accounting = MEMORY_ACCOUNTING_DEFAULT;
         arg_default_tasks_accounting = true;
-        arg_default_tasks_max = UINT64_MAX;
+        arg_default_tasks_max = system_tasks_max_scale(DEFAULT_TASKS_MAX_PERCENTAGE, 100U);
         arg_machine_id = (sd_id128_t) {};
         arg_cad_burst_action = EMERGENCY_ACTION_REBOOT_FORCE;
 
@@ -2102,8 +2102,6 @@ static int parse_configuration(const struct rlimit *saved_rlimit_nofile,
 
         assert(saved_rlimit_nofile);
         assert(saved_rlimit_memlock);
-
-        arg_default_tasks_max = system_tasks_max_scale(DEFAULT_TASKS_MAX_PERCENTAGE, 100U);
 
         /* Assign configuration defaults */
         reset_arguments();


### PR DESCRIPTION
Otherwise DefaultTasksMax is always set to "inifinity".

This was broken by fb39af4ce42.

(cherry picked from commit c0000de87d2c7934cb1f4ba66a533a85277600ff)

Resolves: #1809037