### PR TITLE
(#1823767) Testsuite backports

### DIFF
--- a/catalog/meson.build
+++ b/catalog/meson.build
@@ -17,7 +17,6 @@ in_files = '''
 
 support_url = get_option('support-url')
 support_sed = 's~%SUPPORT_URL%~@0@~'.format(support_url)
-build_catalog_dir = meson.current_build_dir()
 
 foreach file : in_files
         custom_target(

--- a/src/shared/tests.h
+++ b/src/shared/tests.h
@@ -2,5 +2,6 @@
 #pragma once
 
 char* setup_fake_runtime_dir(void);
+bool test_is_running_from_builddir(char **exedir);
 const char* get_testdata_dir(const char *suffix);
 void test_setup_logging(int level);

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -766,7 +766,7 @@ tests += [
          [threads,
           libxz,
           liblz4],
-         '', '', '-DCATALOG_DIR="@0@"'.format(build_catalog_dir)],
+         '', '', '-DCATALOG_DIR="@0@"'.format(catalogdir)],
 
         [['src/journal/test-compress.c'],
          [libjournal_core,

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -616,14 +616,24 @@ static void test_exec_privatenetwork(Manager *m) {
 
 static void test_exec_oomscoreadjust(Manager *m) {
         test(m, "exec-oomscoreadjust-positive.service", 0, CLD_EXITED);
+
+        if (detect_container() > 0) {
+                log_notice("Testing in container, skipping remaining tests in %s", __func__);
+                return;
+        }
         test(m, "exec-oomscoreadjust-negative.service", 0, CLD_EXITED);
 }
 
 static void test_exec_ioschedulingclass(Manager *m) {
         test(m, "exec-ioschedulingclass-none.service", 0, CLD_EXITED);
         test(m, "exec-ioschedulingclass-idle.service", 0, CLD_EXITED);
-        test(m, "exec-ioschedulingclass-realtime.service", 0, CLD_EXITED);
         test(m, "exec-ioschedulingclass-best-effort.service", 0, CLD_EXITED);
+
+        if (detect_container() > 0) {
+                log_notice("Testing in container, skipping remaining tests in %s", __func__);
+                return;
+        }
+        test(m, "exec-ioschedulingclass-realtime.service", 0, CLD_EXITED);
 }
 
 static void test_exec_unsetenvironment(Manager *m) {

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -317,6 +317,8 @@ static void test_exec_temporaryfilesystem(Manager *m) {
 
 static void test_exec_systemcallfilter(Manager *m) {
 #if HAVE_SECCOMP
+        int r;
+
         if (!is_seccomp_available()) {
                 log_notice("Seccomp not available, skipping %s", __func__);
                 return;
@@ -326,6 +328,13 @@ static void test_exec_systemcallfilter(Manager *m) {
         test(m, "exec-systemcallfilter-not-failing2.service", 0, CLD_EXITED);
         test(m, "exec-systemcallfilter-failing.service", SIGSYS, CLD_KILLED);
         test(m, "exec-systemcallfilter-failing2.service", SIGSYS, CLD_KILLED);
+
+        r = find_binary("python3", NULL);
+        if (r < 0) {
+                log_notice_errno(r, "Skipping remaining tests in %s, could not find python3 binary: %m", __func__);
+                return;
+        }
+
         test(m, "exec-systemcallfilter-with-errno-name.service", errno_from_name("EILSEQ"), CLD_EXITED);
         test(m, "exec-systemcallfilter-with-errno-number.service", 255, CLD_EXITED);
 #endif
@@ -333,8 +342,16 @@ static void test_exec_systemcallfilter(Manager *m) {
 
 static void test_exec_systemcallerrornumber(Manager *m) {
 #if HAVE_SECCOMP
+        int r;
+
         if (!is_seccomp_available()) {
                 log_notice("Seccomp not available, skipping %s", __func__);
+                return;
+        }
+
+        r = find_binary("python3", NULL);
+        if (r < 0) {
+                log_notice_errno(r, "Skipping %s, could not find python3 binary: %m", __func__);
                 return;
         }
 

--- a/src/test/test-fs-util.c
+++ b/src/test/test-fs-util.c
@@ -17,6 +17,7 @@
 #include "strv.h"
 #include "user-util.h"
 #include "util.h"
+#include "virt.h"
 
 static void test_chase_symlinks(void) {
         _cleanup_free_ char *result = NULL;
@@ -468,6 +469,7 @@ static void test_touch_file(void) {
         struct stat st;
         const char *a;
         usec_t test_mtime;
+        int r;
 
         test_uid = geteuid() == 0 ? 65534 : getuid();
         test_gid = geteuid() == 0 ? 65534 : getgid();
@@ -517,7 +519,12 @@ static void test_touch_file(void) {
 
         if (geteuid() == 0) {
                 a = strjoina(p, "/cdev");
-                assert_se(mknod(a, 0775 | S_IFCHR, makedev(0, 0)) >= 0);
+                r = mknod(a, 0775 | S_IFCHR, makedev(0, 0));
+                if (r < 0 && errno == EPERM && detect_container() > 0) {
+                        log_notice("Running in unprivileged container? Skipping remaining tests in %s", __func__);
+                        return;
+                }
+                assert_se(r >= 0);
                 assert_se(touch_file(a, false, test_mtime, test_uid, test_gid, 0640) >= 0);
                 assert_se(lstat(a, &st) >= 0);
                 assert_se(st.st_uid == test_uid);

--- a/src/test/test-process-util.c
+++ b/src/test/test-process-util.c
@@ -394,12 +394,17 @@ static void test_rename_process_now(const char *p, int ret) {
         log_info("comm = <%s>", comm);
         assert_se(strneq(comm, p, TASK_COMM_LEN-1));
 
-        assert_se(get_process_cmdline(0, 0, false, &cmdline) >= 0);
+        r = get_process_cmdline(0, 0, false, &cmdline);
+        assert_se(r >= 0);
         /* we cannot expect cmdline to be renamed properly without privileges */
         if (geteuid() == 0) {
-                log_info("cmdline = <%s>", cmdline);
-                assert_se(strneq(p, cmdline, STRLEN("test-process-util")));
-                assert_se(startswith(p, cmdline));
+                if (r == 0 && detect_container() > 0)
+                        log_info("cmdline = <%s> (not verified, Running in unprivileged container?)", cmdline);
+                else {
+                        log_info("cmdline = <%s>", cmdline);
+                        assert_se(strneq(p, cmdline, STRLEN("test-process-util")));
+                        assert_se(startswith(p, cmdline));
+                }
         } else
                 log_info("cmdline = <%s> (not verified)", cmdline);
 }

--- a/test/TEST-17-UDEV-WANTS/Makefile
+++ b/test/TEST-17-UDEV-WANTS/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-18-FAILUREACTION/Makefile
+++ b/test/TEST-18-FAILUREACTION/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-19-DELEGATE/Makefile
+++ b/test/TEST-19-DELEGATE/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-20-MAINPIDGAMES/Makefile
+++ b/test/TEST-20-MAINPIDGAMES/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-21-SYSUSERS/Makefile
+++ b/test/TEST-21-SYSUSERS/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-21-SYSUSERS/test.sh
+++ b/test/TEST-21-SYSUSERS/test.sh
@@ -15,6 +15,7 @@ prepare_testdir() {
         for i in $1.initial-{passwd,group,shadow}; do
                 test -f $i && cp $i $TESTDIR/etc/${i#*.initial-}
         done
+        return 0
 }
 
 preprocess() {

--- a/test/TEST-22-TMPFILES/Makefile
+++ b/test/TEST-22-TMPFILES/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-23-TYPE-EXEC/Makefile
+++ b/test/TEST-23-TYPE-EXEC/Makefile
@@ -1,4 +1,1 @@
-BUILD_DIR=$(shell ../../tools/find-build-dir.sh)
-
-all setup clean run:
-	@basedir=../.. TEST_BASE_DIR=../ BUILD_DIR=$(BUILD_DIR) ./test.sh --$@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-24-UNIT-TESTS/test.sh
+++ b/test/TEST-24-UNIT-TESTS/test.sh
@@ -78,6 +78,8 @@ test_setup() {
         setup_basic_environment
         install_keymaps yes
         install_zoneinfo
+        # Install nproc to determine # of CPUs for correct parallelization
+        inst_binary nproc
 
         # setup the testsuite service
         cat >$initdir/etc/systemd/system/testsuite.service <<EOF

--- a/test/TEST-24-UNIT-TESTS/testsuite.sh
+++ b/test/TEST-24-UNIT-TESTS/testsuite.sh
@@ -4,31 +4,84 @@
 #set -ex
 #set -o pipefail
 
-for i in /usr/lib/systemd/tests/test-*; do
-    if [[ ! -x $i ]]; then continue; fi
-    NAME=${i##*/}
-    echo "Running $NAME"
-    $i > /$NAME.log 2>&1
-    ret=$?
-    if (( $ret && $ret != 77 )); then
-        echo "$NAME failed with $ret"
-        echo $NAME >> /failed-tests
-        echo "--- $NAME begin ---" >> /failed
-        cat /$NAME.log >> /failed
-        echo "--- $NAME end ---" >> /failed
-    elif (( $ret == 77 )); then
-        echo "$NAME skipped"
-        echo $NAME >> /skipped-tests
-        echo "--- $NAME begin ---" >> /skipped
-        cat /$NAME.log >> /skipped
-        echo "--- $NAME end ---" >> /skipped
-    else
-        echo "$NAME OK"
-        echo $NAME >> /testok
+NPROC=$(nproc)
+MAX_QUEUE_SIZE=${NPROC:-2}
+IFS=$'\n' TEST_LIST=($(ls /usr/lib/systemd/tests/test-*))
+
+# Check & report test results
+# Arguments:
+#   $1: test path
+#   $2: test exit code
+function report_result() {
+    if [[ $# -ne 2 ]]; then
+        echo >&2 "check_result: missing arguments"
+        exit 1
     fi
 
-    systemd-cat echo "--- $NAME ---"
-    systemd-cat cat /$NAME.log
+    local name="${1##*/}"
+    local ret=$2
+
+    if [[ $ret -ne 0 && $ret != 77 ]]; then
+        echo "$name failed with $ret"
+        echo "$name" >> /failed-tests
+        {
+            echo "--- $name begin ---"
+            cat "/$name.log"
+            echo "--- $name end ---"
+        } >> /failed
+    elif [[ $ret == 77 ]]; then
+        echo "$name skipped"
+        echo "$name" >> /skipped-tests
+        {
+            echo "--- $name begin ---"
+            cat "/$name.log"
+            echo "--- $name end ---"
+        } >> /skipped
+    else
+        echo "$name OK"
+        echo "$name" >> /testok
+    fi
+
+    systemd-cat echo "--- $name ---"
+    systemd-cat cat "/$name.log"
+}
+
+# Associative array for running tasks, where running[test-path]=PID
+declare -A running=()
+for task in "${TEST_LIST[@]}"; do
+    # If there's MAX_QUEUE_SIZE running tasks, keep checking the running queue
+    # until one of the tasks finishes, so we can replace it.
+    while [[ ${#running[@]} -ge $MAX_QUEUE_SIZE ]]; do
+        for key in "${!running[@]}"; do
+            if ! kill -0 ${running[$key]} &>/dev/null; then
+                # Task has finished, report its result and drop it from the queue
+                wait ${running[$key]}
+                ec=$?
+                report_result "$key" $ec
+                unset running["$key"]
+                # Break from inner for loop and outer while loop to skip
+                # the sleep below when we find a free slot in the queue
+                break 2
+            fi
+        done
+
+        # Precisely* calculated constant to keep the spinlock from burning the CPU(s)
+        sleep 0.01
+    done
+
+    if [[ -x $task ]]; then
+        log_file="/${task##*/}.log"
+        $task &> "$log_file" &
+        running[$task]=$!
+    fi
+done
+
+# Wait for remaining running tasks
+for key in "${!running[@]}"; do
+    wait ${running[$key]}
+    ec=$?
+    report_result "$key" $ec
+    unset running["$key"]
 done
 
 exit 0

--- a/test/test-functions
+++ b/test/test-functions
@@ -449,7 +449,7 @@ EOF
 }
 
 check_result_nspawn() {
-    ret=1
+    local ret=1
     [[ -e $TESTDIR/$1/testok ]] && ret=0
     [[ -f $TESTDIR/$1/failed ]] && cp -a $TESTDIR/$1/failed $TESTDIR
     cp -a $TESTDIR/$1/var/log/journal $TESTDIR
@@ -462,7 +462,7 @@ check_result_nspawn() {
 
 # can be overridden in specific test
 check_result_qemu() {
-    ret=1
+    local ret=1
     mkdir -p $TESTDIR/root
     mount ${LOOPDEV}p1 $TESTDIR/root
     [[ -e $TESTDIR/root/testok ]] && ret=0
@@ -1527,7 +1527,9 @@ do_test() {
         case $1 in
             --run)
                 echo "TEST RUN: $TEST_DESCRIPTION"
-                if test_run; then
+                test_run
+                ret=$?
+                if (( $ret == 0 )); then
                     echo "TEST RUN: $TEST_DESCRIPTION [OK]"
                 else
                     echo "TEST RUN: $TEST_DESCRIPTION [FAILED]"

--- a/test/test-functions
+++ b/test/test-functions
@@ -630,6 +630,16 @@ install_keymaps() {
             [[ -f $i ]] || continue
             inst $i
     done
+
+    # When it takes any argument, then install more keymaps.
+    if [[ -n $1 ]]; then
+        for i in \
+        /usr/lib/kbd/keymaps/i386/*/* \
+        /usr/lib/kbd/keymaps/legacy/i386/*/*; do
+            [[ -f $i ]] || continue
+            inst $i
+        done
+    fi
 }
 
 install_zoneinfo() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -628,6 +628,13 @@ install_keymaps() {
     done
 }
 
+install_zoneinfo() {
+    for i in /usr/share/zoneinfo/{,*/,*/*/}*; do
+        [[ -f $i ]] || continue
+        inst $i
+    done
+}
+
 install_fonts() {
     for i in \
         /usr/lib/kbd/consolefonts/eurlatgr* \

--- a/test/test-functions
+++ b/test/test-functions
@@ -420,6 +420,8 @@ install_systemd() {
 
     # enable debug logging in PID1
     echo LogLevel=debug >> $initdir/etc/systemd/system.conf
+    # store coredumps in journal
+    echo Storage=journal >> $initdir/etc/systemd/coredump.conf
 }
 
 get_ldpath() {

--- a/test/test-functions
+++ b/test/test-functions
@@ -420,7 +420,7 @@ get_ldpath() {
 
 install_missing_libraries() {
     # install possible missing libraries
-    for i in $initdir{,/usr}/{sbin,bin}/* $initdir{,/usr}/lib/systemd/*; do
+    for i in $initdir{,/usr}/{sbin,bin}/* $initdir{,/usr}/lib/systemd/{,tests/{,manual/,unsafe/}}*; do
         LD_LIBRARY_PATH=$(get_ldpath $i) inst_libs $i
     done
 }

--- a/test/test-functions
+++ b/test/test-functions
@@ -120,7 +120,16 @@ run_qemu() {
         fi
     fi
 
-    [ "$QEMU_SMP" ]   || QEMU_SMP=1
+    # If QEMU_SMP was not explicitly set, try to determine the value 'dynamically'
+    # i.e. use the number of online CPUs on the host machine. If the nproc utility
+    # is not installed or there's some other error when calling it, fall back
+    # to the original value (QEMU_SMP=1).
+    if ! [ "$QEMU_SMP" ]; then
+        if ! QEMU_SMP=$(nproc); then
+            dwarn "nproc utility is not installed, falling back to QEMU_SMP=1"
+            QEMU_SMP=1
+        fi
+    fi
 
     find_qemu_bin || return 1
 

--- a/test/test-functions
+++ b/test/test-functions
@@ -619,10 +619,14 @@ install_pam() {
 }
 
 install_keymaps() {
+    # The first three paths may be deprecated.
+    # It seems now the last two paths are used by many distributions.
     for i in \
         /usr/lib/kbd/keymaps/include/* \
         /usr/lib/kbd/keymaps/i386/include/* \
-        /usr/lib/kbd/keymaps/i386/qwerty/us.*; do
+        /usr/lib/kbd/keymaps/i386/qwerty/us.* \
+        /usr/lib/kbd/keymaps/legacy/include/* \
+        /usr/lib/kbd/keymaps/legacy/i386/qwerty/us.*; do
             [[ -f $i ]] || continue
             inst $i
     done


### PR DESCRIPTION
`TEST-24-UNIT-TESTS` is completely broken and what's worse - the test fail was masked as well.

The first patch resolves the return code masking issue, whereas the rest fixes the uncovered test errors. Also, the patchset extends the test coverage, so now the unit tests are run under QEMU and in both privileged and unprivileged systemd-nspawn containers. Lastly, I pulled down my parallelization patch from upstream which significantly speeds up the test on multi-core machines (in CentOS CI the runtime went from 21 minutes to 14 minutes).

The last patch is not relevant to `TEST-24-UNIT-TEST` by itself, but it's going to help with https://github.com/systemd/systemd-centos-ci/pull/242.

Resolves: #1823767