### PR TITLE
(#1748840) mount: don't add Requires for tmp.mount

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -305,7 +305,7 @@ static int mount_add_mount_dependencies(Mount *m) {
                 if (r < 0)
                         return r;
 
-                if (UNIT(m)->fragment_path) {
+                if (UNIT(m)->fragment_path && !streq(UNIT(m)->id, "tmp.mount")) {
                         /* If we have fragment configuration, then make this dependency required */
                         r = unit_add_dependency(other, UNIT_REQUIRES, UNIT(m), true, UNIT_DEPENDENCY_PATH);
                         if (r < 0)


### PR DESCRIPTION
This is a follow-up to #1619292.

rhel-only
Resolves: #1748840