### PR TITLE
(#1868877) mount-setup: fix segfault in mount_cgroup_controllers when using gcc9…

### DIFF
--- a/src/core/mount-setup.c
+++ b/src/core/mount-setup.c
@@ -237,20 +237,22 @@ int mount_cgroup_controllers(char ***join_controllers) {
         if (!cg_is_legacy_wanted())
                 return 0;
 
+        /* The defaults:
+         * mount "cpu" + "cpuacct" together, and "net_cls" + "net_prio".
+         *
+         * We'd like to add "cpuset" to the mix, but "cpuset" doesn't really
+         * work for groups with no initialized attributes.
+         */
+        char ***default_join_controllers = (char**[]) {
+                STRV_MAKE("cpu", "cpuacct"),
+                STRV_MAKE("net_cls", "net_prio"),
+                NULL,
+        };
+
         /* Mount all available cgroup controllers that are built into the kernel. */
 
         if (!has_argument)
-                /* The defaults:
-                 * mount "cpu" + "cpuacct" together, and "net_cls" + "net_prio".
-                 *
-                 * We'd like to add "cpuset" to the mix, but "cpuset" doesn't really
-                 * work for groups with no initialized attributes.
-                 */
-                join_controllers = (char**[]) {
-                        STRV_MAKE("cpu", "cpuacct"),
-                        STRV_MAKE("net_cls", "net_prio"),
-                        NULL,
-                };
+                join_controllers = default_join_controllers;
 
         r = cg_kernel_controllers(&controllers);
         if (r < 0)


### PR DESCRIPTION
… compiler

According to the documentation:
https://gcc.gnu.org/gcc-9/porting_to.html#complit

The 'join_controllers' that relied on the extended lifetime needs
to be fixed, move the compound literals to the function scope it
need to accessible in.