### PR TITLE
(#1868831): cgroup: freezer action must be NOP when cgroup v2 freezer is not available

### DIFF
--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -2936,6 +2936,9 @@ int unit_cgroup_freezer_action(Unit *u, FreezerAction action) {
         assert(u);
         assert(IN_SET(action, FREEZER_FREEZE, FREEZER_THAW));
 
+        if (!cg_freezer_supported())
+                return 0;
+
         if (!u->cgroup_realized)
                 return -EBUSY;
 


### PR DESCRIPTION
Low-level cgroup freezer state manipulation is invoked directly from the
job engine when we are about to execute the job in order to make sure
the unit is not frozen and job execution is not blocked because of
that.

Currently with cgroup v1 we would needlessly do a bunch of work in the
function and even falsely update the freezer state. Don't do any of this
and skip the function silently when v2 freezer is not available.

Following bug is fixed by this commit,

$ systemd-run --unit foo.service /bin/sleep infinity
$ systemctl restart foo.service
$ systemctl show -p FreezerState foo.service

Before (cgroup v1, i.e. full "legacy" mode):
FreezerState=thawing

After:
FreezerState=running

(cherry picked from commit 9a1e90aee556b7a30d87553a891a4175ae77ed68)

Resolves: #1868831