### PR TITLE
(#1885553) sd-bus: break the loop in bus_ensure_running() if the bus is not conn…

### DIFF
--- a/src/libsystemd/sd-bus/sd-bus.c
+++ b/src/libsystemd/sd-bus/sd-bus.c
@@ -2059,12 +2059,13 @@ int bus_ensure_running(sd_bus *bus) {
 
         assert(bus);
 
-        if (IN_SET(bus->state, BUS_UNSET, BUS_CLOSED, BUS_CLOSING))
-                return -ENOTCONN;
         if (bus->state == BUS_RUNNING)
                 return 1;
 
         for (;;) {
+                if (IN_SET(bus->state, BUS_UNSET, BUS_CLOSED, BUS_CLOSING))
+                        return -ENOTCONN;
+
                 r = sd_bus_process(bus, NULL);
                 if (r < 0)
                         return r;


### PR DESCRIPTION
…ecting

This might fix #17025:
> the call trace is
> bus_ensure_running -> sd_bus_process -> bus_process_internal -> process_closeing --> sd_bus_close
>                                                                                  |
>                                                                                  \-> process_match

We ended doing callouts to the Disconnected matches from bus_ensure_running()
and shouldn't. bus_ensure_running() should never do callouts. This change
should fix this however: once we notice that the connection is going down we
will now fail instantly with ENOTOCONN instead of calling any callbacks.

(cherry picked from commit 93a59b1ae5d3bcb0ec1488ebc13d0d1ff4d1729a)

Resolves: #1885553