### PR TITLE
(#1870638) socket: New option 'FlushPending' (boolean) to flush socket before en…

### DIFF
--- a/doc/TRANSIENT-SETTINGS.md
+++ b/doc/TRANSIENT-SETTINGS.md
@@ -388,6 +388,7 @@ Most socket unit settings are available to transient units.
 ✓ SocketMode=
 ✓ DirectoryMode=
 ✓ Accept=
+✓ FlushPending=
 ✓ Writable=
 ✓ MaxConnections=
 ✓ MaxConnectionsPerSource=

--- a/man/systemd.socket.xml
+++ b/man/systemd.socket.xml
@@ -426,6 +426,18 @@
       </varlistentry>
 
       <varlistentry>
+        <term><varname>FlushPending=</varname></term>
+        <listitem><para>Takes a boolean argument. May only be used when
+        <option>Accept=no</option>. If yes, the socket's buffers are cleared after the
+        triggered service exited. This causes any pending data to be
+        flushed and any pending incoming connections to be rejected. If no, the
+        socket's buffers won't be cleared, permitting the service to handle any
+        pending connections after restart, which is the usually expected behaviour.
+        Defaults to <option>no</option>.
+        </para></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>MaxConnections=</varname></term>
         <listitem><para>The maximum number of connections to
         simultaneously run services instances for, when

--- a/src/core/dbus-socket.c
+++ b/src/core/dbus-socket.c
@@ -85,6 +85,7 @@ const sd_bus_vtable bus_socket_vtable[] = {
         SD_BUS_PROPERTY("SocketMode", "u", bus_property_get_mode, offsetof(Socket, socket_mode), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("DirectoryMode", "u", bus_property_get_mode, offsetof(Socket, directory_mode), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("Accept", "b", bus_property_get_bool, offsetof(Socket, accept), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("FlushPending", "b", bus_property_get_bool, offsetof(Socket, flush_pending), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("Writable", "b", bus_property_get_bool, offsetof(Socket, writable), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("KeepAlive", "b", bus_property_get_bool, offsetof(Socket, keep_alive), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("KeepAliveTimeUSec", "t", bus_property_get_usec, offsetof(Socket, keep_alive_time), SD_BUS_VTABLE_PROPERTY_CONST),
@@ -176,6 +177,9 @@ static int bus_socket_set_transient_property(
 
         if (streq(name, "Accept"))
                 return bus_set_transient_bool(u, name, &s->accept, message, flags, error);
+
+        if (streq(name, "FlushPending"))
+                return bus_set_transient_bool(u, name, &s->flush_pending, message, flags, error);
 
         if (streq(name, "Writable"))
                 return bus_set_transient_bool(u, name, &s->writable, message, flags, error);

--- a/src/core/load-fragment-gperf.gperf.m4
+++ b/src/core/load-fragment-gperf.gperf.m4
@@ -359,6 +359,7 @@ Socket.SocketGroup,              config_parse_user_group,            0,         
 Socket.SocketMode,               config_parse_mode,                  0,                             offsetof(Socket, socket_mode)
 Socket.DirectoryMode,            config_parse_mode,                  0,                             offsetof(Socket, directory_mode)
 Socket.Accept,                   config_parse_bool,                  0,                             offsetof(Socket, accept)
+Socket.FlushPending,             config_parse_bool,                  0,                             offsetof(Socket, flush_pending)
 Socket.Writable,                 config_parse_bool,                  0,                             offsetof(Socket, writable)
 Socket.MaxConnections,           config_parse_unsigned,              0,                             offsetof(Socket, max_connections)
 Socket.MaxConnectionsPerSource,  config_parse_unsigned,              0,                             offsetof(Socket, max_connections_per_source)

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -109,6 +109,7 @@ struct Socket {
         bool accept;
         bool remove_on_stop;
         bool writable;
+        bool flush_pending;
 
         int socket_protocol;
 

--- a/src/shared/bus-unit-util.c
+++ b/src/shared/bus-unit-util.c
@@ -1468,7 +1468,8 @@ static int bus_append_socket_property(sd_bus_message *m, const char *field, cons
 
         if (STR_IN_SET(field,
                        "Accept", "Writable", "KeepAlive", "NoDelay", "FreeBind", "Transparent", "Broadcast",
-                       "PassCredentials", "PassSecurity", "ReusePort", "RemoveOnStop", "SELinuxContextFromNet"))
+                       "PassCredentials", "PassSecurity", "ReusePort", "RemoveOnStop", "SELinuxContextFromNet",
+                       "FlushPending"))
 
                 return bus_append_parse_boolean(m, field, eq);
 


### PR DESCRIPTION
…tering listening state

Disabled by default. When Enabled, before listening on the socket, flush the content.
Applies when Accept=no only.

(cherry picked from commit 3e5f04bf6468fcb79c080f02b0eab08f258bff0c)

Resolves: #1870636