### PR TITLE
fix 'Assertion 'access(catalog_dirs[0], F_OK) >= 0' in test-catalog

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -215,6 +215,7 @@ conf.set_quoted('SYSTEM_SHUTDOWN_PATH',                       systemshutdowndir)
 conf.set_quoted('SYSTEM_SLEEP_PATH',                          systemsleepdir)
 conf.set_quoted('SYSTEMD_KBD_MODEL_MAP',                      join_paths(pkgdatadir, 'kbd-model-map'))
 conf.set_quoted('SYSTEMD_LANGUAGE_FALLBACK_MAP',              join_paths(pkgdatadir, 'language-fallback-map'))
+conf.set_quoted('SYSTEMD_TEST_DATA',                          join_paths(testsdir, 'testdata'))
 conf.set_quoted('UDEVLIBEXECDIR',                             udevlibexecdir)
 conf.set_quoted('POLKIT_AGENT_BINARY_PATH',                   join_paths(bindir, 'pkttyagent'))
 conf.set_quoted('LIBDIR',                                     libdir)
@@ -231,7 +232,6 @@ conf.set('MEMORY_ACCOUNTING_DEFAULT',                         memory_accounting_
 conf.set_quoted('MEMORY_ACCOUNTING_DEFAULT_YES_NO',           memory_accounting_default ? 'yes' : 'no')
 
 conf.set_quoted('ABS_BUILD_DIR',                              meson.build_root())
-conf.set_quoted('ABS_SRC_DIR',                                meson.source_root())
 
 substs.set('prefix',                                          prefixdir)
 substs.set('exec_prefix',                                     prefixdir)
@@ -2593,6 +2593,14 @@ executable('systemd-sulogin-shell',
            install_dir : rootlibexecdir)
 
 ############################################################
+
+custom_target(
+        'systemd-runtest.env',
+        output : 'systemd-runtest.env',
+        command : ['sh', '-c', '{ ' +
+                   'echo SYSTEMD_TEST_DATA=@0@; '.format(join_paths(meson.current_source_dir(), 'test')) +
+                   '} >@OUTPUT@'],
+        build_by_default : true)
 
 foreach tuple : tests
         sources = tuple[0]

--- a/meson.build
+++ b/meson.build
@@ -216,6 +216,7 @@ conf.set_quoted('SYSTEM_SLEEP_PATH',                          systemsleepdir)
 conf.set_quoted('SYSTEMD_KBD_MODEL_MAP',                      join_paths(pkgdatadir, 'kbd-model-map'))
 conf.set_quoted('SYSTEMD_LANGUAGE_FALLBACK_MAP',              join_paths(pkgdatadir, 'language-fallback-map'))
 conf.set_quoted('SYSTEMD_TEST_DATA',                          join_paths(testsdir, 'testdata'))
+conf.set_quoted('SYSTEMD_CATALOG_DIR',                        catalogdir)
 conf.set_quoted('UDEVLIBEXECDIR',                             udevlibexecdir)
 conf.set_quoted('POLKIT_AGENT_BINARY_PATH',                   join_paths(bindir, 'pkttyagent'))
 conf.set_quoted('LIBDIR',                                     libdir)
@@ -230,8 +231,6 @@ conf.set_quoted('USER_KEYRING_PATH',                          join_paths(pkgsysc
 conf.set_quoted('DOCUMENT_ROOT',                              join_paths(pkgdatadir, 'gatewayd'))
 conf.set('MEMORY_ACCOUNTING_DEFAULT',                         memory_accounting_default ? 'true' : 'false')
 conf.set_quoted('MEMORY_ACCOUNTING_DEFAULT_YES_NO',           memory_accounting_default ? 'yes' : 'no')
-
-conf.set_quoted('ABS_BUILD_DIR',                              meson.build_root())
 
 substs.set('prefix',                                          prefixdir)
 substs.set('exec_prefix',                                     prefixdir)
@@ -2599,6 +2598,7 @@ custom_target(
         output : 'systemd-runtest.env',
         command : ['sh', '-c', '{ ' +
                    'echo SYSTEMD_TEST_DATA=@0@; '.format(join_paths(meson.current_source_dir(), 'test')) +
+                   'echo SYSTEMD_CATALOG_DIR=@0@; '.format(join_paths(meson.current_build_dir(), 'catalog')) +
                    '} >@OUTPUT@'],
         build_by_default : true)
 

--- a/src/journal/test-catalog.c
+++ b/src/journal/test-catalog.c
@@ -212,11 +212,7 @@ int main(int argc, char *argv[]) {
 
         /* If test-catalog is located at the build directory, then use catalogs in that.
          * If it is not, e.g. installed by systemd-tests package, then use installed catalogs. */
-        if (test_is_running_from_builddir(NULL)) {
-                assert_se(catalog_dir = path_join(NULL, ABS_BUILD_DIR, "catalog"));
-                catalog_dirs = STRV_MAKE(catalog_dir);
-        } else
-                catalog_dirs = STRV_MAKE(CATALOG_DIR);
+        catalog_dirs = STRV_MAKE(get_catalog_dir());
 
         assert_se(access(catalog_dirs[0], F_OK) >= 0);
         log_notice("Using catalog directory '%s'", catalog_dirs[0]);

--- a/src/shared/tests.c
+++ b/src/shared/tests.c
@@ -44,12 +44,6 @@ static void load_testdata_env(void) {
                 setenv(*k, *v, 0);
 }
 
-bool test_is_running_from_builddir(char **exedir) {
-        load_testdata_env();
-
-        return !!getenv("SYSTEMD_TEST_DATA");
-}
-
 const char* get_testdata_dir(void) {
         const char *env;
 
@@ -71,4 +65,20 @@ void test_setup_logging(int level) {
         log_set_max_level(level);
         log_parse_environment();
         log_open();
+}
+
+const char* get_catalog_dir(void) {
+        const char *env;
+
+        load_testdata_env();
+
+        /* if the env var is set, use that */
+        env = getenv("SYSTEMD_CATALOG_DIR");
+        if (!env)
+                env = SYSTEMD_CATALOG_DIR;
+        if (access(env, F_OK) < 0) {
+                fprintf(stderr, "ERROR: $SYSTEMD_CATALOG_DIR directory [%s] does not exist\n", env);
+                exit(EXIT_FAILURE);
+        }
+        return env;
 }

--- a/src/shared/tests.c
+++ b/src/shared/tests.c
@@ -6,8 +6,11 @@
 #include <stdlib.h>
 #include <util.h>
 
-#include "tests.h"
+#include "alloc-util.h"
+#include "fileio.h"
 #include "path-util.h"
+#include "strv.h"
+#include "tests.h"
 
 char* setup_fake_runtime_dir(void) {
         char t[] = "/tmp/fake-xdg-runtime-XXXXXX", *p;
@@ -19,55 +22,49 @@ char* setup_fake_runtime_dir(void) {
         return p;
 }
 
-bool test_is_running_from_builddir(char **exedir) {
+static void load_testdata_env(void) {
+        static bool called = false;
         _cleanup_free_ char *s = NULL;
-        bool r;
+        _cleanup_free_ char *envpath = NULL;
+        _cleanup_strv_free_ char **pairs = NULL;
+        char **k, **v;
 
-        /* Check if we're running from the builddir. Optionally, this returns
-         * the path to the directory where the binary is located. */
+        if (called)
+                return;
+        called = true;
 
         assert_se(readlink_and_make_absolute("/proc/self/exe", &s) >= 0);
-        r = path_startswith(s, ABS_BUILD_DIR);
+        dirname(s);
 
-        if (exedir) {
-                dirname(s);
-                *exedir = TAKE_PTR(s);
-        }
+        envpath = path_join(NULL, s, "systemd-runtest.env");
+        if (load_env_file_pairs(NULL, envpath, NULL, &pairs) < 0)
+                return;
 
-        return r;
+        STRV_FOREACH_PAIR(k, v, pairs)
+                setenv(*k, *v, 0);
+}
+
+bool test_is_running_from_builddir(char **exedir) {
+        load_testdata_env();
+
+        return !!getenv("SYSTEMD_TEST_DATA");
 }
 
 const char* get_testdata_dir(void) {
         const char *env;
-        /* convenience: caller does not need to free result */
-        static char testdir[PATH_MAX];
+
+        load_testdata_env();
 
         /* if the env var is set, use that */
         env = getenv("SYSTEMD_TEST_DATA");
-        testdir[sizeof(testdir) - 1] = '\0';
-        if (env) {
-                if (access(env, F_OK) < 0) {
-                        fputs("ERROR: $SYSTEMD_TEST_DATA directory does not exist\n", stderr);
-                        exit(EXIT_FAILURE);
-                }
-                strncpy(testdir, env, sizeof(testdir) - 1);
-        } else {
-                _cleanup_free_ char *exedir = NULL;
-
-                /* Check if we're running from the builddir. If so, use the compiled in path. */
-                if (test_is_running_from_builddir(&exedir))
-                        assert_se(snprintf(testdir, sizeof(testdir), "%s/test", ABS_SRC_DIR) > 0);
-                else
-                        /* Try relative path, according to the install-test layout */
-                        assert_se(snprintf(testdir, sizeof(testdir), "%s/testdata", exedir) > 0);
-
-                if (access(testdir, F_OK) < 0) {
-                        fputs("ERROR: Cannot find testdata directory, set $SYSTEMD_TEST_DATA\n", stderr);
-                        exit(EXIT_FAILURE);
-                }
+        if (!env)
+                env = SYSTEMD_TEST_DATA;
+        if (access(env, F_OK) < 0) {
+                fprintf(stderr, "ERROR: $SYSTEMD_TEST_DATA directory [%s] does not exist\n", env);
+                exit(EXIT_FAILURE);
         }
 
-        return testdir;
+        return env;
 }
 
 void test_setup_logging(int level) {

--- a/src/shared/tests.h
+++ b/src/shared/tests.h
@@ -2,6 +2,6 @@
 #pragma once
 
 char* setup_fake_runtime_dir(void);
-bool test_is_running_from_builddir(char **exedir);
 const char* get_testdata_dir(void);
+const char* get_catalog_dir(void);
 void test_setup_logging(int level);

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -776,8 +776,7 @@ tests += [
           libshared],
          [threads,
           libxz,
-          liblz4],
-         '', '', '-DCATALOG_DIR="@0@"'.format(catalogdir)],
+          liblz4]],
 
         [['src/journal/test-compress.c'],
          [libjournal_core,


### PR DESCRIPTION
It's problematic that we use STRV_MAKE() (i.e. a compound initializer) outside of the {} block.
Hence, let's backport the following two patches to fix it.

Fixes: d9b6baa69968132d33e4ad8627c7fe0bd527c859 (“test: make test-catalog relocatable”)
