### PR TITLE
(#1657810) cgroup: Also set blkio.bfq.weight

### DIFF
--- a/src/core/cgroup.c
+++ b/src/core/cgroup.c
@@ -1063,6 +1063,14 @@ static void cgroup_context_apply(
                                 log_unit_full(u, IN_SET(r, -ENOENT, -EROFS, -EACCES) ? LOG_DEBUG : LOG_WARNING, r,
                                               "Failed to set blkio.weight: %m");
 
+                        /* FIXME: drop this when distro kernels properly support BFQ through "blkio.weight"
+                         * See also: https://github.com/systemd/systemd/pull/13335 */
+                        xsprintf(buf, "%" PRIu64 "\n", weight);
+                        r = cg_set_attribute("blkio", path, "blkio.bfq.weight", buf);
+                        if (r < 0)
+                                log_unit_full(u, IN_SET(r, -ENOENT, -EROFS, -EACCES) ? LOG_DEBUG : LOG_WARNING, r,
+                                              "Failed to set blkio.bfq.weight: %m");
+
                         if (has_io) {
                                 CGroupIODeviceWeight *w;
 

--- a/units/initrd-switch-root.target
+++ b/units/initrd-switch-root.target
@@ -15,4 +15,4 @@ Requires=initrd-switch-root.service
 Before=initrd-switch-root.service
 AllowIsolate=yes
 Wants=initrd-udevadm-cleanup-db.service initrd-root-fs.target initrd-fs.target systemd-journald.service initrd-cleanup.service
-After=initrd-udevadm-cleanup-db.service initrd-root-fs.target initrd-fs.target emergency.service emergency.target
+After=initrd-udevadm-cleanup-db.service initrd-root-fs.target initrd-fs.target emergency.service emergency.target initrd-cleanup.service


### PR DESCRIPTION
Commit [1] added a workaround when unified cgroups are used but missed
legacy cgroups where there is the same issue.

[1] <https://github.com/systemd/systemd/commit/2dbc45aea747f25cc1c3848fded2ec0062f96bcf>

Signed-off-by: Pavel Hrdina <phrdina@redhat.com>
(cherry picked from commit 35e7a62ca32a30169a94693b831e53c832251984)

Resolves: #1657810