### PR TITLE
(#1827462) udev/net_id: give RHEL-8.4 naming scheme a name

### DIFF
--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -150,6 +150,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-8.1", NAMING_RHEL_8_1 },
         { "rhel-8.2", NAMING_RHEL_8_2 },
         { "rhel-8.3", NAMING_RHEL_8_3 },
+        { "rhel-8.4", NAMING_RHEL_8_4 },
         /* … add more schemes here, as the logic to name devices is updated … */
 };
 


### PR DESCRIPTION
Follow-up for bb6114af097da0cd9c5081e42db718559130687f

Related: #1827462