### PR TITLE
(#1871827) ci: PowerTools repo was renamed to powertools in RHEL 8.3

### DIFF
--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -95,7 +95,7 @@ for phase in "${PHASES[@]}"; do
             # Upgrade the container to get the most recent environment
             $DOCKER_EXEC dnf -y upgrade
             # Install systemd's build dependencies
-            $DOCKER_EXEC dnf -q -y --enablerepo "PowerTools" builddep systemd
+            $DOCKER_EXEC dnf -q -y --enablerepo "powertools" builddep systemd
             ;;
         RUN)
             info "Run phase"

--- a/ci/travis-centos-rhel8.sh
+++ b/ci/travis-centos-rhel8.sh
@@ -81,11 +81,11 @@ for phase in "${PHASES[@]}"; do
             info "Setup phase"
             info "Using Travis $CENTOS_RELEASE"
             # Pull a Docker image and start a new container
-            docker pull centos:$CENTOS_RELEASE
+            docker pull quay.io/centos/centos:$CENTOS_RELEASE
             info "Starting container $CONT_NAME"
             $DOCKER_RUN -v $REPO_ROOT:/build:rw \
                         -w /build --privileged=true --name $CONT_NAME \
-                        -dit --net=host centos:$CENTOS_RELEASE /sbin/init
+                        -dit --net=host quay.io/centos/centos:$CENTOS_RELEASE /sbin/init
             # Beautiful workaround for Fedora's version of Docker
             sleep 1
             $DOCKER_EXEC dnf makecache


### PR DESCRIPTION
See: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS8.2011#Yum_repo_file_and_repoid_changes

rhel-only
Related: #1871827