### PR TITLE
(#1940078) man: document differences in clean exit status for Type=oneshot

### DIFF
--- a/man/systemd.service.xml
+++ b/man/systemd.service.xml
@@ -669,14 +669,19 @@
         If set to <option>no</option> (the default), the service will
         not be restarted. If set to <option>on-success</option>, it
         will be restarted only when the service process exits cleanly.
-        In this context, a clean exit means an exit code of 0, or one
-        of the signals
-        <constant>SIGHUP</constant>,
-        <constant>SIGINT</constant>,
-        <constant>SIGTERM</constant> or
-        <constant>SIGPIPE</constant>, and
-        additionally, exit statuses and signals specified in
-        <varname>SuccessExitStatus=</varname>. If set to
+        In this context, a clean exit means any of the following:
+        <itemizedlist>
+            <listitem><simpara>exit code of 0;</simpara></listitem>
+            <listitem><simpara>for types other than
+            <varname>Type=oneshot</varname>, one of the signals
+                <constant>SIGHUP</constant>,
+                <constant>SIGINT</constant>,
+                <constant>SIGTERM</constant>, or
+                <constant>SIGPIPE</constant>;</simpara></listitem>
+            <listitem><simpara>exit statuses and signals specified in
+                <varname>SuccessExitStatus=</varname>.</simpara></listitem>
+        </itemizedlist>
+        If set to
         <option>on-failure</option>, the service will be restarted
         when the process exits with a non-zero exit code, is
         terminated by a signal (including on core dump, but excluding
@@ -798,7 +803,8 @@
         <listitem><para>Takes a list of exit status definitions that,
         when returned by the main service process, will be considered
         successful termination, in addition to the normal successful
-        exit code 0 and the signals <constant>SIGHUP</constant>,
+        exit code 0 and, except for <varname>Type=oneshot</varname>,
+        the signals <constant>SIGHUP</constant>,
         <constant>SIGINT</constant>, <constant>SIGTERM</constant>, and
         <constant>SIGPIPE</constant>. Exit status definitions can
         either be numeric exit codes or termination signal names,


### PR DESCRIPTION
See commit 1f0958f640b87175cd547c1e69084cfe54a22e9d .

(cherry picked from commit f055cf77862bc580f3afbfaac161d1c060f39411)

Resolves: #1940078