### PR TITLE
(#1946453) Backport upstream commit related to user-runtime-dir@.service

### DIFF
--- a/src/login/user-runtime-dir.c
+++ b/src/login/user-runtime-dir.c
@@ -95,20 +95,19 @@ static int user_remove_runtime_path(const char *runtime_path) {
 
         r = rm_rf(runtime_path, 0);
         if (r < 0)
-                log_error_errno(r, "Failed to remove runtime directory %s (before unmounting): %m", runtime_path);
+                log_debug_errno(r, "Failed to remove runtime directory %s (before unmounting), ignoring: %m", runtime_path);
 
-        /* Ignore cases where the directory isn't mounted, as that's
-         * quite possible, if we lacked the permissions to mount
-         * something */
+        /* Ignore cases where the directory isn't mounted, as that's quite possible, if we lacked the permissions to
+         * mount something */
         r = umount2(runtime_path, MNT_DETACH);
         if (r < 0 && !IN_SET(errno, EINVAL, ENOENT))
-                log_error_errno(errno, "Failed to unmount user runtime directory %s: %m", runtime_path);
+                log_debug_errno(errno, "Failed to unmount user runtime directory %s, ignoring: %m", runtime_path);
 
         r = rm_rf(runtime_path, REMOVE_ROOT);
-        if (r < 0)
-                log_error_errno(r, "Failed to remove runtime directory %s (after unmounting): %m", runtime_path);
+        if (r < 0 && r != -ENOENT)
+                return log_error_errno(r, "Failed to remove runtime directory %s (after unmounting): %m", runtime_path);
 
-        return r;
+        return 0;
 }
 
 static int do_mount(const char *runtime_path, uid_t uid, gid_t gid) {

--- a/units/user-runtime-dir@.service.in
+++ b/units/user-runtime-dir@.service.in
@@ -15,3 +15,4 @@ StopWhenUnneeded=yes
 ExecStart=@rootlibexecdir@/systemd-user-runtime-dir start %i
 ExecStop=@rootlibexecdir@/systemd-user-runtime-dir stop %i
 RemainAfterExit=true
+Slice=user-%i.slice

--- a/units/user-runtime-dir@.service.in
+++ b/units/user-runtime-dir@.service.in
@@ -9,6 +9,7 @@
 
 [Unit]
 Description=/run/user/%i mount wrapper
+After=systemd-user-sessions.service
 StopWhenUnneeded=yes
 
 [Service]

--- a/units/user-runtime-dir@.service.in
+++ b/units/user-runtime-dir@.service.in
@@ -15,5 +15,6 @@ StopWhenUnneeded=yes
 [Service]
 ExecStart=@rootlibexecdir@/systemd-user-runtime-dir start %i
 ExecStop=@rootlibexecdir@/systemd-user-runtime-dir stop %i
+Type=oneshot
 RemainAfterExit=true
 Slice=user-%i.slice


### PR DESCRIPTION
user-runtime-dir: downgrade a few log messages to LOG_DEBUG that we ignore
units: make sure user-runtime-dir@.service is Type=oneshot
units: order user-runtime-dir@.service after systemd-user-sessions.service
units: assign user-runtime-dir@.service to user-%i.slice

bz1946453