### PR TITLE
(#1959339) Add support for lenient initramfs detection

### DIFF
--- a/doc/ENVIRONMENT.md
+++ b/doc/ENVIRONMENT.md
@@ -37,6 +37,14 @@ All tools:
   useful for debugging, in order to test generators and other code against
   specific kernel command lines.
 
+* `$SYSTEMD_IN_INITRD=[auto|lenient|0|1]` — if set, specifies initrd detection
+  method. Defaults to `auto`. Behavior is defined as follows:
+  `auto`: Checks if `/etc/initrd-release` exists, and a temporary fs is mounted
+          on `/`. If both conditions meet, then it's in initrd.
+  `lenient`: Similiar to `auto`, but the rootfs check is skipped.
+  `0|1`: Simply overrides initrd detection. This is useful for debugging and
+         testing initrd-only programs in the main system.
+
 * `$SYSTEMD_EMOJI=0` — if set, tools such as "systemd-analyze security" will
   not output graphical smiley emojis, but ASCII alternatives instead. Note that
   this only controls use of Unicode emoji glyphs, and has no effect on other

--- a/src/basic/util.c
+++ b/src/basic/util.c
@@ -130,11 +130,14 @@ int prot_from_flags(int flags) {
 }
 
 bool in_initrd(void) {
+        int r;
+        const char *e;
+        bool lenient = false;
 
         if (saved_in_initrd >= 0)
                 return saved_in_initrd;
 
-        /* We make two checks here:
+        /* We have two checks here:
          *
          * 1. the flag file /etc/initrd-release must exist
          * 2. the root file system must be a memory file system
@@ -142,10 +145,29 @@ bool in_initrd(void) {
          * The second check is extra paranoia, since misdetecting an
          * initrd can have bad consequences due the initrd
          * emptying when transititioning to the main systemd.
+         *
+         * If env var $SYSTEMD_IN_INITRD is not set or set to "auto",
+         * both checks are used. If it's set to "lenient", only check
+         * 1 is used. If set to a booleen value, then the boolean
+         * value is returned.
          */
 
-        saved_in_initrd = access("/etc/initrd-release", F_OK) >= 0 &&
-                          path_is_temporary_fs("/") > 0;
+        e = secure_getenv("SYSTEMD_IN_INITRD");
+        if (e) {
+                if (streq(e, "lenient"))
+                        lenient = true;
+                else if (!streq(e, "auto")) {
+                        r = parse_boolean(e);
+                        if (r >= 0) {
+                                saved_in_initrd = r > 0;
+                                return saved_in_initrd;
+                        }
+                        log_debug_errno(r, "Failed to parse $SYSTEMD_IN_INITRD, ignoring: %m");
+                }
+        }
+
+        saved_in_initrd = (lenient || path_is_temporary_fs("/") > 0) &&
+                          access("/etc/initrd-release", F_OK) >= 0;
 
         return saved_in_initrd;
 }

--- a/src/basic/util.c
+++ b/src/basic/util.c
@@ -166,8 +166,16 @@ bool in_initrd(void) {
                 }
         }
 
-        saved_in_initrd = (lenient || path_is_temporary_fs("/") > 0) &&
-                          access("/etc/initrd-release", F_OK) >= 0;
+        if (!lenient) {
+                r = path_is_temporary_fs("/");
+                if (r < 0)
+                        log_debug_errno(r, "Couldn't determine if / is a temporary file system: %m");
+
+                saved_in_initrd = r > 0;
+        }
+
+        if (saved_in_initrd != 0)
+                saved_in_initrd = access("/etc/initrd-release", F_OK) >= 0;
 
         return saved_in_initrd;
 }

--- a/src/basic/util.c
+++ b/src/basic/util.c
@@ -130,7 +130,6 @@ int prot_from_flags(int flags) {
 }
 
 bool in_initrd(void) {
-        struct statfs s;
 
         if (saved_in_initrd >= 0)
                 return saved_in_initrd;
@@ -146,8 +145,7 @@ bool in_initrd(void) {
          */
 
         saved_in_initrd = access("/etc/initrd-release", F_OK) >= 0 &&
-                          statfs("/", &s) >= 0 &&
-                          is_temporary_fs(&s);
+                          path_is_temporary_fs("/") > 0;
 
         return saved_in_initrd;
 }

--- a/src/basic/util.c
+++ b/src/basic/util.c
@@ -174,8 +174,17 @@ bool in_initrd(void) {
                 saved_in_initrd = r > 0;
         }
 
-        if (saved_in_initrd != 0)
-                saved_in_initrd = access("/etc/initrd-release", F_OK) >= 0;
+        r = access("/etc/initrd-release", F_OK);
+        if (r >= 0) {
+                if (saved_in_initrd == 0)
+                        log_debug("/etc/initrd-release exists, but it's not an initrd.");
+                else
+                        saved_in_initrd = 1;
+        } else {
+                if (errno != ENOENT)
+                        log_debug_errno(errno, "Failed to test if /etc/initrd-release exists: %m");
+                saved_in_initrd = 0;
+        }
 
         return saved_in_initrd;
 }


### PR DESCRIPTION
util: rework in_initrd() to make use of path_is_temporary_fs()
initrd: do a debug log if /etc/initrd-release doesn't take effect
initrd: do a debug log if failed to detect rootfs type
initrd: do a debug log if /etc/initrd-release doesn't take effect