### PR TITLE
(#1970860) meson: remove strange dep that causes meson to enter infinite loop

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -68,7 +68,6 @@ foreach tuple : xsltproc.found() ? manpages : []
                 foreach htmlalias : htmlaliases
                         link = custom_target(
                                 htmlalias,
-                                input : p2,
                                 output : htmlalias,
                                 command : ['ln', '-fs', html, '@OUTPUT@'])
                         if want_html

--- a/src/test/test-copy.c
+++ b/src/test/test-copy.c
@@ -253,6 +253,22 @@ static void test_copy_atomic(void) {
         assert_se(copy_file_atomic("/etc/fstab", q, 0644, 0, COPY_REPLACE) >= 0);
 }
 
+static void test_copy_proc(void) {
+        _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
+        _cleanup_free_ char *f = NULL, *a = NULL, *b = NULL;
+
+        /* Check if copying data from /proc/ works correctly, i.e. let's see if https://lwn.net/Articles/846403/ is a problem for us */
+
+        assert_se(mkdtemp_malloc(NULL, &p) >= 0);
+        assert_se(f = path_join(NULL, p, "version"));
+        assert_se(copy_file("/proc/version", f, 0, (mode_t) -1, 0, 0) >= 0);
+
+        assert_se(read_one_line_file("/proc/version", &a) >= 0);
+        assert_se(read_one_line_file(f, &b) >= 0);
+        assert_se(streq(a, b));
+        assert_se(strlen(a) > 0);
+}
+
 int main(int argc, char *argv[]) {
         log_set_max_level(LOG_DEBUG);
 
@@ -267,6 +283,7 @@ int main(int argc, char *argv[]) {
         test_copy_bytes_regular_file(argv[0], false, 32000); /* larger than copy buffer size */
         test_copy_bytes_regular_file(argv[0], true, 32000);
         test_copy_atomic();
+        test_copy_proc();
 
         return 0;
 }


### PR DESCRIPTION
The value is obviously bogus, but didn't seem to cause problems so far.
With meson-0.52.0, it causes a hang. The number of aliases is always rather
small (usually just one or two, possibly up to a dozen in a few cases), so
even if this causes some looping, it is strange that it has such a huge impact.
But let's just remove it.

Fixes #13742.

Tested with meson-0.52.0-1.module_f31+6771+f5d842eb.noarch,
meson-0.51.1-1.fc29.noarch.

(cherry picked from commit af336643a01d0b210b18312c253a50594ba54b0a)

Resolves: #1970860