### PR TITLE
Fix build with µhttpd 0.9.71

### DIFF
--- a/src/journal-remote/journal-gatewayd.c
+++ b/src/journal-remote/journal-gatewayd.c
@@ -338,7 +338,7 @@ static int request_parse_range(
         return 0;
 }
 
-static int request_parse_arguments_iterator(
+static mhd_result request_parse_arguments_iterator(
                 void *cls,
                 enum MHD_ValueKind kind,
                 const char *key,
@@ -785,7 +785,7 @@ static int request_handler_machine(
         return MHD_queue_response(connection, MHD_HTTP_OK, response);
 }
 
-static int request_handler(
+static mhd_result request_handler(
                 void *cls,
                 struct MHD_Connection *connection,
                 const char *url,

--- a/src/journal-remote/journal-remote-main.c
+++ b/src/journal-remote/journal-remote-main.c
@@ -241,7 +241,7 @@ static int process_http_upload(
         return mhd_respond(connection, MHD_HTTP_ACCEPTED, "OK.");
 };
 
-static int request_handler(
+static mhd_result request_handler(
                 void *cls,
                 struct MHD_Connection *connection,
                 const char *url,

--- a/src/journal-remote/microhttpd-util.h
+++ b/src/journal-remote/microhttpd-util.h
@@ -47,6 +47,12 @@
 #  define MHD_create_response_from_fd_at_offset64 MHD_create_response_from_fd_at_offset
 #endif
 
+#if MHD_VERSION >= 0x00097002
+#  define mhd_result enum MHD_Result
+#else
+#  define mhd_result int
+#endif
+
 void microhttpd_logger(void *arg, const char *fmt, va_list ap) _printf_(2, 0);
 
 /* respond_oom() must be usable with return, hence this form. */


### PR DESCRIPTION
The return type of callbacks was changed from int to an enum.

Compilation fails on Fedora 31, 33, 34 with:

```
[5/11] Compiling C object systemd-journal-gatewayd.p/src_journal-remote_journal-gatewayd.c.o
FAILED: systemd-journal-gatewayd.p/src_journal-remote_journal-gatewayd.c.o 
cc -Isystemd-journal-gatewayd.p -I. -I.. -Isrc/basic -I../src/basic -Isrc/shared -I../src/shared -Isrc/systemd -I../src/systemd -Isrc/journal -I../src/journal -Isrc/journal-remote -I../src/journal-remote -Isrc/nspawn -I../src/nspawn -Isrc/resolve -I../src/resolve -Isrc/timesync -I../src/timesync -I../src/time-wait-sync -Isrc/login -I../src/login -Isrc/udev -I../src/udev -Isrc/libudev -I../src/libudev -Isrc/core -I../src/core -I../src/libsystemd/sd-bus -I../src/libsystemd/sd-device -I../src/libsystemd/sd-hwdb -I../src/libsystemd/sd-id128 -I../src/libsystemd/sd-netlink -I../src/libsystemd/sd-network -Isrc/libsystemd-network -I../src/libsystemd-network -I/usr/include/p11-kit-1 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -g -Wextra -Werror=undef -Wlogical-op -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wfloat-equal -Wsuggest-attribute=noreturn -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=missing-declarations -Werror=return-type -Werror=incompatible-pointer-types -Werror=format=2 -Wstrict-prototypes -Wredundant-decls -Wmissing-noreturn -Wimplicit-fallthrough=5 -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Werror=shift-count-overflow -Werror=shift-overflow=2 -Wdate-time -Wnested-externs -ffast-math -fno-common -fdiagnostics-show-option -fno-strict-aliasing -fvisibility=hidden -fstack-protector -fstack-protector-strong --param=ssp-buffer-size=4 -fPIE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-result -Wno-format-signedness -Wno-error=nonnull -Werror=shadow -include config.h -pthread -MD -MQ systemd-journal-gatewayd.p/src_journal-remote_journal-gatewayd.c.o -MF systemd-journal-gatewayd.p/src_journal-remote_journal-gatewayd.c.o.d -o systemd-journal-gatewayd.p/src_journal-remote_journal-gatewayd.c.o -c ../src/journal-remote/journal-gatewayd.c
../src/journal-remote/journal-gatewayd.c: In function ‘request_parse_arguments’:
../src/journal-remote/journal-gatewayd.c:445:70: error: passing argument 3 of ‘MHD_get_connection_values’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  445 |         MHD_get_connection_values(connection, MHD_GET_ARGUMENT_KIND, request_parse_arguments_iterator, m);
      |                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                      |
      |                                                                      int (*)(void *, enum MHD_ValueKind,  const char *, const char *)
In file included from ../src/journal-remote/journal-gatewayd.c:5:
/usr/include/microhttpd.h:2784:49: note: expected ‘MHD_KeyValueIterator’ {aka ‘enum MHD_Result (*)(void *, enum MHD_ValueKind,  const char *, const char *)’} but argument is of type ‘int (*)(void *, enum MHD_ValueKind,  const char *, const char *)’
 2784 |                            MHD_KeyValueIterator iterator,
      |                            ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
../src/journal-remote/journal-gatewayd.c: In function ‘main’:
../src/journal-remote/journal-gatewayd.c:1023:38: error: passing argument 5 of ‘MHD_start_daemon’ from incompatible pointer type [-Werror=incompatible-pointer-types]
 1023 |                                      request_handler, NULL,
      |                                      ^~~~~~~~~~~~~~~
      |                                      |
      |                                      int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, size_t *, void **) {aka int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, long unsigned int *, void **)}
In file included from ../src/journal-remote/journal-gatewayd.c:5:
/usr/include/microhttpd.h:2480:45: note: expected ‘MHD_AccessHandlerCallback’ {aka ‘enum MHD_Result (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, long unsigned int *, void **)’} but argument is of type ‘int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, size_t *, void **)’ {aka ‘int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, long unsigned int *, void **)’}
 2480 |                   MHD_AccessHandlerCallback dh, void *dh_cls,
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
cc1: some warnings being treated as errors
[7/11] Compiling C object systemd-journal-remote.p/src_journal-remote_journal-remote-main.c.o
FAILED: systemd-journal-remote.p/src_journal-remote_journal-remote-main.c.o 
cc -Isystemd-journal-remote.p -I. -I.. -Isrc/basic -I../src/basic -Isrc/shared -I../src/shared -Isrc/systemd -I../src/systemd -Isrc/journal -I../src/journal -Isrc/journal-remote -I../src/journal-remote -Isrc/nspawn -I../src/nspawn -Isrc/resolve -I../src/resolve -Isrc/timesync -I../src/timesync -I../src/time-wait-sync -Isrc/login -I../src/login -Isrc/udev -I../src/udev -Isrc/libudev -I../src/libudev -Isrc/core -I../src/core -I../src/libsystemd/sd-bus -I../src/libsystemd/sd-device -I../src/libsystemd/sd-hwdb -I../src/libsystemd/sd-id128 -I../src/libsystemd/sd-netlink -I../src/libsystemd/sd-network -Isrc/libsystemd-network -I../src/libsystemd-network -I/usr/include/p11-kit-1 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -g -Wextra -Werror=undef -Wlogical-op -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wfloat-equal -Wsuggest-attribute=noreturn -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=missing-declarations -Werror=return-type -Werror=incompatible-pointer-types -Werror=format=2 -Wstrict-prototypes -Wredundant-decls -Wmissing-noreturn -Wimplicit-fallthrough=5 -Wshadow -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Werror=overflow -Werror=shift-count-overflow -Werror=shift-overflow=2 -Wdate-time -Wnested-externs -ffast-math -fno-common -fdiagnostics-show-option -fno-strict-aliasing -fvisibility=hidden -fstack-protector -fstack-protector-strong --param=ssp-buffer-size=4 -fPIE -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-result -Wno-format-signedness -Wno-error=nonnull -Werror=shadow -include config.h -pthread -MD -MQ systemd-journal-remote.p/src_journal-remote_journal-remote-main.c.o -MF systemd-journal-remote.p/src_journal-remote_journal-remote-main.c.o.d -o systemd-journal-remote.p/src_journal-remote_journal-remote-main.c.o -c ../src/journal-remote/journal-remote-main.c
../src/journal-remote/journal-remote-main.c: In function ‘setup_microhttpd_server’:
../src/journal-remote/journal-remote-main.c:418:38: error: passing argument 5 of ‘MHD_start_daemon’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  418 |                                      request_handler, NULL,
      |                                      ^~~~~~~~~~~~~~~
      |                                      |
      |                                      int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, size_t *, void **) {aka int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, long unsigned int *, void **)}
In file included from ../src/journal-remote/microhttpd-util.h:4,
                 from ../src/journal-remote/journal-remote.h:11,
                 from ../src/journal-remote/journal-remote-main.c:13:
/usr/include/microhttpd.h:2480:45: note: expected ‘MHD_AccessHandlerCallback’ {aka ‘enum MHD_Result (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, long unsigned int *, void **)’} but argument is of type ‘int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, size_t *, void **)’ {aka ‘int (*)(void *, struct MHD_Connection *, const char *, const char *, const char *, const char *, long unsigned int *, void **)’}
 2480 |                   MHD_AccessHandlerCallback dh, void *dh_cls,
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
cc1: some warnings being treated as errors
```