### PR TITLE
(#1954802) core: Hide "Deactivated successfully" message

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -5525,7 +5525,10 @@ int unit_pid_attachable(Unit *u, pid_t pid, sd_bus_error *error) {
 void unit_log_success(Unit *u) {
         assert(u);
 
-        log_struct(LOG_INFO,
+        /* Let's show message "Deactivated successfully" in debug mode (when manager is user) rather than in info mode.
+         * This message has low information value for regular users and it might be a bit overwhelming on a system with
+         * a lot of devices. */
+        log_struct(MANAGER_IS_USER(u->manager) ? LOG_DEBUG : LOG_INFO,
                    "MESSAGE_ID=" SD_MESSAGE_UNIT_SUCCESS_STR,
                    LOG_UNIT_ID(u),
                    LOG_UNIT_INVOCATION_ID(u),


### PR DESCRIPTION
Show message "Deactivated successfully" in debug mode (when manager is
user) rather than in info mode. This message has low information value
for regular users and it might be a bit overwhelming on a system with
a lot of devices.

(cherry picked from commit edf2ee22f54005d76b2fb8fdcc9c60974feb88bc)

Resolves: #1954802