### PR TITLE
(#1968648) CVE-2019-3842 systemd: Spoofing of XDG_SEAT allows for actions to be checked against "allow_active" instead of "allow_any" [rhel-8.3.0.z]

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -68,7 +68,6 @@ foreach tuple : xsltproc.found() ? manpages : []
                 foreach htmlalias : htmlaliases
                         link = custom_target(
                                 htmlalias,
-                                input : p2,
                                 output : htmlalias,
                                 command : ['ln', '-fs', html, '@OUTPUT@'])
                         if want_html

--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -274,6 +274,26 @@ static int append_session_cg_weight(pam_handle_t *handle, sd_bus_message *m, con
         return 0;
 }
 
+static const char* getenv_harder(pam_handle_t *handle, const char *key, const char *fallback) {
+        const char *v;
+
+        assert(handle);
+        assert(key);
+
+        /* Looks for an environment variable, preferrably in the environment block associated with the specified PAM
+         * handle, falling back to the process' block instead. */
+
+        v = pam_getenv(handle, key);
+        if (!isempty(v))
+                return v;
+
+        v = getenv(key);
+        if (!isempty(v))
+                return v;
+
+        return fallback;
+}
+
 _public_ PAM_EXTERN int pam_sm_open_session(
                 pam_handle_t *handle,
                 int flags,
@@ -352,29 +372,11 @@ _public_ PAM_EXTERN int pam_sm_open_session(
         pam_get_item(handle, PAM_RUSER, (const void**) &remote_user);
         pam_get_item(handle, PAM_RHOST, (const void**) &remote_host);
 
-        seat = pam_getenv(handle, "XDG_SEAT");
-        if (isempty(seat))
-                seat = getenv("XDG_SEAT");
-
-        cvtnr = pam_getenv(handle, "XDG_VTNR");
-        if (isempty(cvtnr))
-                cvtnr = getenv("XDG_VTNR");
-
-        type = pam_getenv(handle, "XDG_SESSION_TYPE");
-        if (isempty(type))
-                type = getenv("XDG_SESSION_TYPE");
-        if (isempty(type))
-                type = type_pam;
-
-        class = pam_getenv(handle, "XDG_SESSION_CLASS");
-        if (isempty(class))
-                class = getenv("XDG_SESSION_CLASS");
-        if (isempty(class))
-                class = class_pam;
-
-        desktop = pam_getenv(handle, "XDG_SESSION_DESKTOP");
-        if (isempty(desktop))
-                desktop = getenv("XDG_SESSION_DESKTOP");
+        seat = getenv_harder(handle, "XDG_SEAT", NULL);
+        cvtnr = getenv_harder(handle, "XDG_VTNR", NULL);
+        type = getenv_harder(handle, "XDG_SESSION_TYPE", type_pam);
+        class = getenv_harder(handle, "XDG_SESSION_CLASS", class_pam);
+        desktop = getenv_harder(handle, "XDG_SESSION_DESKTOP", NULL);
 
         tty = strempty(tty);
 

--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -280,14 +280,21 @@ static const char* getenv_harder(pam_handle_t *handle, const char *key, const ch
         assert(handle);
         assert(key);
 
-        /* Looks for an environment variable, preferrably in the environment block associated with the specified PAM
-         * handle, falling back to the process' block instead. */
+        /* Looks for an environment variable, preferrably in the environment block associated with the
+         * specified PAM handle, falling back to the process' block instead. Why check both? Because we want
+         * to permit configuration of session properties from unit files that invoke PAM services, so that
+         * PAM services don't have to be reworked to set systemd-specific properties, but these properties
+         * can still be set from the unit file Environment= block. */
 
         v = pam_getenv(handle, key);
         if (!isempty(v))
                 return v;
 
-        v = getenv(key);
+        /* We use secure_getenv() here, since we might get loaded into su/sudo, which are SUID. Ideally
+         * they'd clean up the environment before invoking foreign code (such as PAM modules), but alas they
+         * currently don't (to be precise, they clean up the environment they pass to their children, but
+         * not their own environ[]). */
+        v = secure_getenv(key);
         if (!isempty(v))
                 return v;
 

--- a/src/test/test-copy.c
+++ b/src/test/test-copy.c
@@ -253,6 +253,22 @@ static void test_copy_atomic(void) {
         assert_se(copy_file_atomic("/etc/fstab", q, 0644, 0, COPY_REPLACE) >= 0);
 }
 
+static void test_copy_proc(void) {
+        _cleanup_(rm_rf_physical_and_freep) char *p = NULL;
+        _cleanup_free_ char *f = NULL, *a = NULL, *b = NULL;
+
+        /* Check if copying data from /proc/ works correctly, i.e. let's see if https://lwn.net/Articles/846403/ is a problem for us */
+
+        assert_se(mkdtemp_malloc(NULL, &p) >= 0);
+        assert_se(f = path_join(NULL, p, "version"));
+        assert_se(copy_file("/proc/version", f, 0, (mode_t) -1, 0, 0) >= 0);
+
+        assert_se(read_one_line_file("/proc/version", &a) >= 0);
+        assert_se(read_one_line_file(f, &b) >= 0);
+        assert_se(streq(a, b));
+        assert_se(strlen(a) > 0);
+}
+
 int main(int argc, char *argv[]) {
         log_set_max_level(LOG_DEBUG);
 
@@ -267,6 +283,7 @@ int main(int argc, char *argv[]) {
         test_copy_bytes_regular_file(argv[0], false, 32000); /* larger than copy buffer size */
         test_copy_bytes_regular_file(argv[0], true, 32000);
         test_copy_atomic();
+        test_copy_proc();
 
         return 0;
 }


### PR DESCRIPTION
pam_systemd: simplify how we process env vars
pam-systemd: use secure_getenv() rather than getenv()

It is also applied for **XDG_VTNR**, **XDG_SESSION_TYPE**, **XDG_SESSION_CLASS** and **XDG_SESSION_DESKTOP** to make it consistent.