### PR TITLE
(#1968650) CVE-2020-13776 systemd: Mishandles numerical usernames beginning with decimal digits or 0x followed by hexadecimal digits

### DIFF
--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -556,7 +556,9 @@ int safe_atou16_full(const char *s, unsigned base, uint16_t *ret) {
                 return -ERANGE;
         if ((unsigned long) (uint16_t) l != l)
                 return -ERANGE;
-        *ret = (uint16_t) l;
+        if (ret)
+                *ret = (uint16_t) l;
+
         return 0;
 }
 

--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -384,20 +384,35 @@ int safe_atou_full(const char *s, unsigned base, unsigned *ret_u) {
 
         assert(s);
         assert(ret_u);
-        assert(base <= 16);
+        assert(SAFE_ATO_MASK_FLAGS(base) <= 16);
 
-        /* strtoul() is happy to parse negative values, and silently
-         * converts them to unsigned values without generating an
-         * error. We want a clean error, hence let's look for the "-"
-         * prefix on our own, and generate an error. But let's do so
-         * only after strtoul() validated that the string is clean
-         * otherwise, so that we return EINVAL preferably over
-         * ERANGE. */
+        /* strtoul() is happy to parse negative values, and silently converts them to unsigned values without
+         * generating an error. We want a clean error, hence let's look for the "-" prefix on our own, and
+         * generate an error. But let's do so only after strtoul() validated that the string is clean
+         * otherwise, so that we return EINVAL preferably over ERANGE. */
+
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_LEADING_WHITESPACE) &&
+            strchr(WHITESPACE, s[0]))
+                return -EINVAL;
 
         s += strspn(s, WHITESPACE);
 
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_PLUS_MINUS) &&
+            IN_SET(s[0], '+', '-'))
+                return -EINVAL; /* Note that we check the "-" prefix again a second time below, but return a
+                                 * different error. I.e. if the SAFE_ATO_REFUSE_PLUS_MINUS flag is set we
+                                 * blanket refuse +/- prefixed integers, while if it is missing we'll just
+                                 * return ERANGE, because the string actually parses correctly, but doesn't
+                                 * fit in the return type. */
+
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_LEADING_ZERO) &&
+            s[0] == '0' && !streq(s, "0"))
+                return -EINVAL; /* This is particularly useful to avoid ambiguities between C's octal
+                                 * notation and assumed-to-be-decimal integers with a leading zero. */
+
         errno = 0;
-        l = strtoul(s, &x, base);
+        l = strtoul(s, &x, SAFE_ATO_MASK_FLAGS(base) /* Let's mask off the flags bits so that only the actual
+                                                      * base is left */);
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)
@@ -431,25 +446,38 @@ int safe_atoi(const char *s, int *ret_i) {
         return 0;
 }
 
-int safe_atollu(const char *s, long long unsigned *ret_llu) {
+int safe_atollu_full(const char *s, unsigned base, long long unsigned *ret_llu) {
         char *x = NULL;
         unsigned long long l;
 
         assert(s);
-        assert(ret_llu);
+        assert(SAFE_ATO_MASK_FLAGS(base) <= 16);
+
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_LEADING_WHITESPACE) &&
+            strchr(WHITESPACE, s[0]))
+                return -EINVAL;
 
         s += strspn(s, WHITESPACE);
 
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_PLUS_MINUS) &&
+            IN_SET(s[0], '+', '-'))
+                return -EINVAL;
+
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_LEADING_ZERO) &&
+            s[0] == '0' && s[1] != 0)
+                return -EINVAL;
+
         errno = 0;
-        l = strtoull(s, &x, 0);
+        l = strtoull(s, &x, base);
+        l = strtoull(s, &x, SAFE_ATO_MASK_FLAGS(base));
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)
                 return -EINVAL;
         if (*s == '-')
                 return -ERANGE;
-
-        *ret_llu = l;
+        if (ret_llu)
+                *ret_llu = l;
         return 0;
 }
 
@@ -501,12 +529,25 @@ int safe_atou16_full(const char *s, unsigned base, uint16_t *ret) {
 
         assert(s);
         assert(ret);
-        assert(base <= 16);
+        assert(SAFE_ATO_MASK_FLAGS(base) <= 16);
+
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_LEADING_WHITESPACE) &&
+            strchr(WHITESPACE, s[0]))
+                return -EINVAL;
 
         s += strspn(s, WHITESPACE);
 
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_PLUS_MINUS) &&
+            IN_SET(s[0], '+', '-'))
+                return -EINVAL;
+
+        if (FLAGS_SET(base, SAFE_ATO_REFUSE_LEADING_ZERO) &&
+            s[0] == '0' && s[1] != 0)
+                return -EINVAL;
+
         errno = 0;
         l = strtoul(s, &x, base);
+        l = strtoul(s, &x, SAFE_ATO_MASK_FLAGS(base));
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)
@@ -515,7 +556,6 @@ int safe_atou16_full(const char *s, unsigned base, uint16_t *ret) {
                 return -ERANGE;
         if ((unsigned long) (uint16_t) l != l)
                 return -ERANGE;
-
         *ret = (uint16_t) l;
         return 0;
 }

--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -417,7 +417,7 @@ int safe_atou_full(const char *s, unsigned base, unsigned *ret_u) {
                 return -errno;
         if (!x || x == s || *x != 0)
                 return -EINVAL;
-        if (s[0] == '-')
+        if (l != 0 && s[0] == '-')
                 return -ERANGE;
         if ((unsigned long) (unsigned) l != l)
                 return -ERANGE;
@@ -474,7 +474,7 @@ int safe_atollu_full(const char *s, unsigned base, long long unsigned *ret_llu) 
                 return -errno;
         if (!x || x == s || *x != 0)
                 return -EINVAL;
-        if (*s == '-')
+        if (l != 0 && s[0] == '-')
                 return -ERANGE;
         if (ret_llu)
                 *ret_llu = l;
@@ -514,7 +514,7 @@ int safe_atou8(const char *s, uint8_t *ret) {
                 return -errno;
         if (!x || x == s || *x != 0)
                 return -EINVAL;
-        if (s[0] == '-')
+        if (l != 0 && s[0] == '-')
                 return -ERANGE;
         if ((unsigned long) (uint8_t) l != l)
                 return -ERANGE;
@@ -552,7 +552,7 @@ int safe_atou16_full(const char *s, unsigned base, uint16_t *ret) {
                 return -errno;
         if (!x || x == s || *x != 0)
                 return -EINVAL;
-        if (s[0] == '-')
+        if (l != 0 && s[0] == '-')
                 return -ERANGE;
         if ((unsigned long) (uint16_t) l != l)
                 return -ERANGE;

--- a/src/basic/parse-util.c
+++ b/src/basic/parse-util.c
@@ -17,6 +17,7 @@
 #include "parse-util.h"
 #include "process-util.h"
 #include "string-util.h"
+#include "strv.h"
 
 int parse_boolean(const char *v) {
         assert(v);
@@ -376,6 +377,32 @@ finish:
 
 }
 
+static const char *mangle_base(const char *s, unsigned *base) {
+        const char *k;
+
+        assert(s);
+        assert(base);
+
+        /* Base already explicitly specified, then don't do anything. */
+        if (SAFE_ATO_MASK_FLAGS(*base) != 0)
+                return s;
+
+        /* Support Python 3 style "0b" and 0x" prefixes, because they truly make sense, much more than C's "0" prefix for octal. */
+        k = STARTSWITH_SET(s, "0b", "0B");
+        if (k) {
+                *base = 2 | (*base & SAFE_ATO_ALL_FLAGS);
+                return k;
+        }
+
+        k = STARTSWITH_SET(s, "0o", "0O");
+        if (k) {
+                *base = 8 | (*base & SAFE_ATO_ALL_FLAGS);
+                return k;
+        }
+
+        return s;
+}
+
 int safe_atou_full(const char *s, unsigned base, unsigned *ret_u) {
         char *x = NULL;
         unsigned long l;
@@ -408,6 +435,8 @@ int safe_atou_full(const char *s, unsigned base, unsigned *ret_u) {
                 return -EINVAL; /* This is particularly useful to avoid ambiguities between C's octal
                                  * notation and assumed-to-be-decimal integers with a leading zero. */
 
+        s = mangle_base(s, &base);
+
         errno = 0;
         l = strtoul(s, &x, SAFE_ATO_MASK_FLAGS(base) /* Let's mask off the flags bits so that only the actual
                                                       * base is left */);
@@ -425,14 +454,18 @@ int safe_atou_full(const char *s, unsigned base, unsigned *ret_u) {
 }
 
 int safe_atoi(const char *s, int *ret_i) {
+        unsigned base = 0;
         char *x = NULL;
         long l;
 
         assert(s);
         assert(ret_i);
 
+        s += strspn(s, WHITESPACE);
+        s = mangle_base(s, &base);
+
         errno = 0;
-        l = strtol(s, &x, 0);
+        l = strtol(s, &x, base);
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)
@@ -465,6 +498,8 @@ int safe_atollu_full(const char *s, unsigned base, long long unsigned *ret_llu) 
             s[0] == '0' && s[1] != 0)
                 return -EINVAL;
 
+        s = mangle_base(s, &base);
+
         errno = 0;
         l = strtoull(s, &x, base);
         l = strtoull(s, &x, SAFE_ATO_MASK_FLAGS(base));
@@ -480,14 +515,18 @@ int safe_atollu_full(const char *s, unsigned base, long long unsigned *ret_llu) 
 }
 
 int safe_atolli(const char *s, long long int *ret_lli) {
+        unsigned base = 0;
         char *x = NULL;
         long long l;
 
         assert(s);
         assert(ret_lli);
 
+        s += strspn(s, WHITESPACE);
+        s = mangle_base(s, &base);
+
         errno = 0;
-        l = strtoll(s, &x, 0);
+        l = strtoll(s, &x, base);
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)
@@ -498,16 +537,18 @@ int safe_atolli(const char *s, long long int *ret_lli) {
 }
 
 int safe_atou8(const char *s, uint8_t *ret) {
-        char *x = NULL;
+        unsigned base = 0;
         unsigned long l;
+        char *x = NULL;
 
         assert(s);
         assert(ret);
 
         s += strspn(s, WHITESPACE);
+        s = mangle_base(s, &base);
 
         errno = 0;
-        l = strtoul(s, &x, 0);
+        l = strtoul(s, &x, base);
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)
@@ -543,6 +584,8 @@ int safe_atou16_full(const char *s, unsigned base, uint16_t *ret) {
             s[0] == '0' && s[1] != 0)
                 return -EINVAL;
 
+        s = mangle_base(s, &base);
+
         errno = 0;
         l = strtoul(s, &x, base);
         l = strtoul(s, &x, SAFE_ATO_MASK_FLAGS(base));
@@ -561,14 +604,18 @@ int safe_atou16_full(const char *s, unsigned base, uint16_t *ret) {
 }
 
 int safe_atoi16(const char *s, int16_t *ret) {
+        unsigned base = 0;
         char *x = NULL;
         long l;
 
         assert(s);
         assert(ret);
 
+        s += strspn(s, WHITESPACE);
+        s = mangle_base(s, &base);
+
         errno = 0;
-        l = strtol(s, &x, 0);
+        l = strtol(s, &x, base);
         if (errno > 0)
                 return -errno;
         if (!x || x == s || *x != 0)

--- a/src/basic/strv.h
+++ b/src/basic/strv.h
@@ -136,6 +136,18 @@ void strv_print(char **l);
                 _x && strv_contains(STRV_MAKE(__VA_ARGS__), _x); \
         })
 
+#define STARTSWITH_SET(p, ...)                                  \
+        ({                                                      \
+                const char *_p = (p);                           \
+                char  *_found = NULL, **_i;                     \
+                STRV_FOREACH(_i, STRV_MAKE(__VA_ARGS__)) {      \
+                        _found = startswith(_p, *_i);           \
+                        if (_found)                             \
+                                break;                          \
+                }                                               \
+                _found;                                         \
+        })
+
 #define FOREACH_STRING(x, ...)                               \
         for (char **_l = ({                                  \
                 char **_ll = STRV_MAKE(__VA_ARGS__);         \

--- a/src/basic/user-util.c
+++ b/src/basic/user-util.c
@@ -49,7 +49,7 @@ int parse_uid(const char *s, uid_t *ret) {
         assert(s);
 
         assert_cc(sizeof(uid_t) == sizeof(uint32_t));
-        r = safe_atou32(s, &uid);
+        r = safe_atou32_full(s, 10, &uid);
         if (r < 0)
                 return r;
 

--- a/src/basic/user-util.c
+++ b/src/basic/user-util.c
@@ -49,7 +49,15 @@ int parse_uid(const char *s, uid_t *ret) {
         assert(s);
 
         assert_cc(sizeof(uid_t) == sizeof(uint32_t));
-        r = safe_atou32_full(s, 10, &uid);
+
+        /* We are very strict when parsing UIDs, and prohibit +/- as prefix, leading zero as prefix, and
+         * whitespace. We do this, since this call is often used in a context where we parse things as UID
+         * first, and if that doesn't work we fall back to NSS. Thus we really want to make sure that UIDs
+         * are parsed as UIDs only if they really really look like UIDs. */
+        r = safe_atou32_full(s, 10
+                             | SAFE_ATO_REFUSE_PLUS_MINUS
+                             | SAFE_ATO_REFUSE_LEADING_ZERO
+                             | SAFE_ATO_REFUSE_LEADING_WHITESPACE, &uid);
         if (r < 0)
                 return r;
 

--- a/src/test/test-parse-util.c
+++ b/src/test/test-parse-util.c
@@ -75,14 +75,22 @@ static void test_parse_mode(void) {
         mode_t m;
 
         assert_se(parse_mode("-1", &m) < 0);
+        assert_se(parse_mode("+1", &m) < 0);
         assert_se(parse_mode("", &m) < 0);
         assert_se(parse_mode("888", &m) < 0);
         assert_se(parse_mode("77777", &m) < 0);
 
         assert_se(parse_mode("544", &m) >= 0 && m == 0544);
+        assert_se(parse_mode("0544", &m) >= 0 && m == 0544);
+        assert_se(parse_mode("00544", &m) >= 0 && m == 0544);
         assert_se(parse_mode("777", &m) >= 0 && m == 0777);
+        assert_se(parse_mode("0777", &m) >= 0 && m == 0777);
+        assert_se(parse_mode("00777", &m) >= 0 && m == 0777);
         assert_se(parse_mode("7777", &m) >= 0 && m == 07777);
+        assert_se(parse_mode("07777", &m) >= 0 && m == 07777);
+        assert_se(parse_mode("007777", &m) >= 0 && m == 07777);
         assert_se(parse_mode("0", &m) >= 0 && m == 0);
+        assert_se(parse_mode(" 1", &m) >= 0 && m == 1);
 }
 
 static void test_parse_size(void) {
@@ -358,6 +366,18 @@ static void test_safe_atolli(void) {
         assert_se(r == 0);
         assert_se(l == -12345);
 
+        r = safe_atolli("0x5", &l);
+        assert_se(r == 0);
+        assert_se(l == 5);
+
+        r = safe_atolli("0o6", &l);
+        assert_se(r == 0);
+        assert_se(l == 6);
+
+        r = safe_atolli("0B101", &l);
+        assert_se(r == 0);
+        assert_se(l == 5);
+
         r = safe_atolli("12345678901234567890", &l);
         assert_se(r == -ERANGE);
 
@@ -431,6 +451,14 @@ static void test_safe_atoi16(void) {
         assert_se(r == 0);
         assert_se(l == 32767);
 
+        r = safe_atoi16("0o11", &l);
+        assert_se(r == 0);
+        assert_se(l == 9);
+
+        r = safe_atoi16("0B110", &l);
+        assert_se(r == 0);
+        assert_se(l == 6);
+
         r = safe_atoi16("36536", &l);
         assert_se(r == -ERANGE);
 
@@ -475,6 +503,13 @@ static void test_safe_atoux16(void) {
         r = safe_atoux16("  -1", &l);
         assert_se(r == -ERANGE);
 
+        r = safe_atoux16("0b1", &l);
+        assert_se(r == 0);
+        assert_se(l == 177);
+
+        r = safe_atoux16("0o70", &l);
+        assert_se(r == -EINVAL);
+
         r = safe_atoux16("junk", &l);
         assert_se(r == -EINVAL);
 
@@ -499,6 +534,14 @@ static void test_safe_atou64(void) {
         r = safe_atou64("  12345", &l);
         assert_se(r == 0);
         assert_se(l == 12345);
+
+        r = safe_atou64("0o11", &l);
+        assert_se(r == 0);
+        assert_se(l == 9);
+
+        r = safe_atou64("0b11", &l);
+        assert_se(r == 0);
+        assert_se(l == 3);
 
         r = safe_atou64("18446744073709551617", &l);
         assert_se(r == -ERANGE);
@@ -541,6 +584,14 @@ static void test_safe_atoi64(void) {
         r = safe_atoi64("  32767", &l);
         assert_se(r == 0);
         assert_se(l == 32767);
+
+        r = safe_atoi64("  0o20", &l);
+        assert_se(r == 0);
+        assert_se(l == 16);
+
+        r = safe_atoi64("  0b01010", &l);
+        assert_se(r == 0);
+        assert_se(l == 10);
 
         r = safe_atoi64("9223372036854775813", &l);
         assert_se(r == -ERANGE);

--- a/src/test/test-strv.c
+++ b/src/test/test-strv.c
@@ -56,6 +56,20 @@ static void test_strptr_in_set(void) {
         assert_se(!STRPTR_IN_SET(NULL, NULL));
 }
 
+static void test_startswith_set(void) {
+        assert_se(!STARTSWITH_SET("foo", "bar", "baz", "waldo"));
+        assert_se(!STARTSWITH_SET("foo", "bar"));
+
+        assert_se(STARTSWITH_SET("abc", "a", "ab", "abc"));
+        assert_se(STARTSWITH_SET("abc", "ax", "ab", "abc"));
+        assert_se(STARTSWITH_SET("abc", "ax", "abx", "abc"));
+        assert_se(!STARTSWITH_SET("abc", "ax", "abx", "abcx"));
+
+        assert_se(streq_ptr(STARTSWITH_SET("foobar", "hhh", "kkk", "foo", "zzz"), "bar"));
+        assert_se(streq_ptr(STARTSWITH_SET("foobar", "hhh", "kkk", "", "zzz"), "foobar"));
+        assert_se(streq_ptr(STARTSWITH_SET("", "hhh", "kkk", "zzz", ""), ""));
+}
+
 static const char* const input_table_multiple[] = {
         "one",
         "two",
@@ -700,6 +714,7 @@ int main(int argc, char *argv[]) {
         test_specifier_printf();
         test_str_in_set();
         test_strptr_in_set();
+        test_startswith_set();
         test_strv_foreach();
         test_strv_foreach_backwards();
         test_strv_foreach_pair();

--- a/src/test/test-user-util.c
+++ b/src/test/test-user-util.c
@@ -40,6 +40,22 @@ static void test_parse_uid(void) {
 
         log_info("/* %s */", __func__);
 
+        r = parse_uid("0", &uid);
+        assert_se(r == 0);
+        assert_se(uid == 0);
+
+        r = parse_uid("1", &uid);
+        assert_se(r == 0);
+        assert_se(uid == 1);
+
+        r = parse_uid("01", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 1);
+
+        r = parse_uid("001", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 1);
+
         r = parse_uid("100", &uid);
         assert_se(r == 0);
         assert_se(uid == 100);
@@ -49,6 +65,14 @@ static void test_parse_uid(void) {
         assert_se(uid == 100);
 
         r = parse_uid("0x1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("0o1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("0b1234", &uid);
         assert_se(r == -EINVAL);
         assert_se(uid == 100);
 
@@ -68,11 +92,27 @@ static void test_parse_uid(void) {
         assert_se(r == -EINVAL);
         assert_se(uid == 100);
 
+        r = parse_uid("001234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("0001234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
         r = parse_uid("-0", &uid);
         assert_se(r == -EINVAL);
         assert_se(uid == 100);
 
         r = parse_uid("+0", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("00", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("000", &uid);
         assert_se(r == -EINVAL);
         assert_se(uid == 100);
 

--- a/src/test/test-user-util.c
+++ b/src/test/test-user-util.c
@@ -46,9 +46,19 @@ static void test_parse_uid(void) {
 
         r = parse_uid("65535", &uid);
         assert_se(r == -ENXIO);
+        assert_se(uid == 100);
+
+        r = parse_uid("0x1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("01234", &uid);
+        assert_se(r == 0);
+        assert_se(uid == 1234);
 
         r = parse_uid("asdsdas", &uid);
         assert_se(r == -EINVAL);
+        assert_se(uid == 1234);
 }
 
 static void test_uid_ptr(void) {

--- a/src/test/test-user-util.c
+++ b/src/test/test-user-util.c
@@ -52,13 +52,33 @@ static void test_parse_uid(void) {
         assert_se(r == -EINVAL);
         assert_se(uid == 100);
 
+        r = parse_uid("+1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("-1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid(" 1234", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
         r = parse_uid("01234", &uid);
-        assert_se(r == 0);
-        assert_se(uid == 1234);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("-0", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
+
+        r = parse_uid("+0", &uid);
+        assert_se(r == -EINVAL);
+        assert_se(uid == 100);
 
         r = parse_uid("asdsdas", &uid);
         assert_se(r == -EINVAL);
-        assert_se(uid == 1234);
+        assert_se(uid == 100);
 }
 
 static void test_uid_ptr(void) {


### PR DESCRIPTION
basic/user-util: always use base 10 for user/group numbers
parse-util: allow tweaking how to parse integers
parse-util: allow '-0' as alternative to '0' and '+0'
parse-util: make return parameter optional in safe_atou16_full()
parse-util: rewrite parse_mode() on top of safe_atou_full()
user-util: be stricter in parse_uid()
strv: add new macro STARTSWITH_SET()
parse-util: also parse integers prefixed with 0b and 0o
tests: beef up integer parsing tests