### PR TITLE
(#1970860) remove a left-over break

### DIFF
--- a/src/basic/copy.c
+++ b/src/basic/copy.c
@@ -218,7 +218,6 @@ int copy_bytes_full(
                                         break;
 
                                 try_sendfile = try_splice = false; /* same logic as above for copy_file_range() */
-                                break;
                         } else
                                 /* Success! */
                                 goto next;


### PR DESCRIPTION
By the "same logic as above...", we want to continue to fallback here,
but the break prohibits that.

This is a follow-up for ee1aa61c4710ae567a2b844e0f0bb8cb0456ab8c .

(cherry picked from commit 99df1cb6f50875db513a5b45f18191460a150f3d)

Related: #1970860