### PR TITLE
(#12697260 extend inhibitor lock enforcement to root

### DIFF
--- a/man/systemctl.xml
+++ b/man/systemctl.xml
@@ -324,22 +324,34 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-i</option></term>
-        <term><option>--ignore-inhibitors</option></term>
+        <term><option>--check-inhibitors=</option></term>
 
         <listitem>
-          <para>When system shutdown or a sleep state is requested,
-          ignore inhibitor locks. Applications can establish inhibitor
-          locks to avoid that certain important operations (such as CD
-          burning or suchlike) are interrupted by system shutdown or a
-          sleep state. Any user may take these locks and privileged
-          users may override these locks. If any locks are taken,
-          shutdown and sleep state requests will normally fail
-          (regardless of whether privileged or not) and a list of active locks
-          is printed. However, if <option>--ignore-inhibitors</option>
-          is specified, the locks are ignored and not printed, and the
-          operation attempted anyway, possibly requiring additional
-          privileges.</para>
+          <para>When system shutdown or sleep state is request, this option controls how to deal with
+          inhibitor locks. It takes one of <literal>auto</literal>, <literal>yes</literal> or
+          <literal>no</literal>. Defaults to <literal>auto</literal>, which will behave like
+          <literal>yes</literal> for interactive invocations (i.e. from a TTY) and <literal>no</literal>
+          for non-interactive invocations.
+          <literal>yes</literal> will let the request respect inhibitor locks.
+          <literal>no</literal> will let the request ignore inhibitor locks.
+          </para>
+          <para>Applications can establish inhibitor locks to avoid that certain important operations
+          (such as CD burning or suchlike) are interrupted by system shutdown or a sleep state. Any user may
+          take these locks and privileged users may override these locks.
+          If any locks are taken, shutdown and sleep state requests will normally fail (unless privileged)
+          and a list of active locks is printed.
+          However, if <literal>no</literal> is specified or <literal>auto</literal> is specified on a
+          non-interactive requests, the established locks are ignored and not shown, and the operation
+          attempted anyway, possibly requiring additional privileges.
+          May be overriden by <option>--force</option>.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-i</option></term>
+
+        <listitem>
+          <para>Shortcut for <option>--check-inhibitors=no</option>.</para>
         </listitem>
       </varlistentry>
 

--- a/shell-completion/bash/systemctl.in
+++ b/shell-completion/bash/systemctl.in
@@ -111,9 +111,9 @@ _systemctl () {
                [STANDALONE]='--all -a --reverse --after --before --defaults --force -f --full -l --global
                              --help -h --no-ask-password --no-block --no-legend --no-pager --no-reload --no-wall --now
                              --quiet -q --system --user --version --runtime --recursive -r --firmware-setup
-                             --show-types -i --ignore-inhibitors --plain --failed --value --fail --dry-run --wait'
+                             --show-types --plain --failed --value --fail --dry-run --wait'
                       [ARG]='--host -H --kill-who --property -p --signal -s --type -t --state --job-mode --root
-                             --preset-mode -n --lines -o --output -M --machine --message'
+                             --preset-mode -n --lines -o --output -M --machine --message --check-inhibitors'
         )
 
         if __contains_word "--user" ${COMP_WORDS[*]}; then
@@ -162,6 +162,9 @@ _systemctl () {
                         ;;
                         --machine|-M)
                                 comps=$( __get_machines )
+                        ;;
+                        --check-inhibitors)
+                                comps='auto yes no'
                         ;;
                 esac
                 COMPREPLY=( $(compgen -W '$comps' -- "$cur") )

--- a/shell-completion/zsh/_systemctl.in
+++ b/shell-completion/zsh/_systemctl.in
@@ -363,6 +363,13 @@ _job_modes() {
     _values -s , "${_modes[@]}"
 }
 
+(( $+functions[_systemctl_check_inhibitors] )) ||
+    _systemctl_check_inhibitors() {
+        local -a _modes
+        _modes=(auto yes no)
+        _values -s , "${_modes[@]}"
+    }
+
 # Build arguments for "systemctl" to be used in completion.
 local -a _modes; _modes=("--user" "--system")
 # Use the last mode (they are exclusive and the last one is used).
@@ -380,7 +387,7 @@ _arguments -s \
     '--before[Show units ordered before]' \
     {-l,--full}"[Don't ellipsize unit names on output]" \
     '--show-types[When showing sockets, show socket type]' \
-    {-i,--ignore-inhibitors}'[When executing a job, ignore jobs dependencies]' \
+    '--check-inhibitors[Specify if inhibitors should be checked]:mode:_systemctl_check_inhibitors' \
     {-q,--quiet}'[Suppress output]' \
     '--no-block[Do not wait until operation finished]' \
     '--no-legend[Do not print a legend, i.e. the column headers and the footer with hints]' \

--- a/src/basic/login-util.h
+++ b/src/basic/login-util.h
@@ -4,6 +4,14 @@
 #include <stdbool.h>
 #include <unistd.h>
 
+#define SD_LOGIND_ROOT_CHECK_INHIBITORS           (UINT64_C(1) << 0)
+
+/* For internal use only */
+#define SD_LOGIND_INTERACTIVE                     (UINT64_C(1) << 63)
+
+#define SD_LOGIND_SHUTDOWN_AND_SLEEP_FLAGS_PUBLIC (SD_LOGIND_ROOT_CHECK_INHIBITORS)
+#define SD_LOGIND_SHUTDOWN_AND_SLEEP_FLAGS_ALL    (SD_LOGIND_ROOT_CHECK_INHIBITORS|SD_LOGIND_INTERACTIVE)
+
 bool session_id_valid(const char *id);
 
 static inline bool logind_running(void) {

--- a/src/login/org.freedesktop.login1.conf
+++ b/src/login/org.freedesktop.login1.conf
@@ -132,7 +132,15 @@
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
+                       send_member="PowerOffWithFlags"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
                        send_member="Reboot"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
+                       send_member="RebootWithFlags"/>
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
@@ -140,7 +148,15 @@
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
+                       send_member="HaltWithFlags"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
                        send_member="Suspend"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
+                       send_member="SuspendWithFlags"/>
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
@@ -148,11 +164,23 @@
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
+                       send_member="HibernateWithFlags"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
                        send_member="HybridSleep"/>
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
+                       send_member="HybridSleepWithFlags"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
                        send_member="SuspendThenHibernate"/>
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
+                       send_member="SuspendThenHibernateWithFlags"/>
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"

--- a/src/systemd/sd-bus-vtable.h
+++ b/src/systemd/sd-bus-vtable.h
@@ -65,10 +65,12 @@ struct sd_bus_vtable {
                         const char *result;
                         sd_bus_message_handler_t handler;
                         size_t offset;
+                        const char *names;
                 } method;
                 struct {
                         const char *member;
                         const char *signature;
+                        const char *names;
                 } signal;
                 struct {
                         const char *member;
@@ -91,7 +93,10 @@ struct sd_bus_vtable {
                 },                                                      \
         }
 
-#define SD_BUS_METHOD_WITH_OFFSET(_member, _signature, _result, _handler, _offset, _flags)   \
+/* helper macro to format method and signal parameters, one at a time */
+#define SD_BUS_PARAM(x) #x "\0"
+
+#define SD_BUS_METHOD_WITH_NAMES_OFFSET(_member, _signature, _in_names, _result, _out_names, _handler, _offset, _flags) \
         {                                                               \
                 .type = _SD_BUS_VTABLE_METHOD,                          \
                 .flags = _flags,                                        \
@@ -102,13 +107,18 @@ struct sd_bus_vtable {
                         .result = _result,                              \
                         .handler = _handler,                            \
                         .offset = _offset,                              \
+                        .names = _in_names _out_names,                  \
                     },                                                  \
                 },                                                      \
         }
+#define SD_BUS_METHOD_WITH_OFFSET(_member, _signature, _result, _handler, _offset, _flags)   \
+        SD_BUS_METHOD_WITH_NAMES_OFFSET(_member, _signature, "", _result, "", _handler, _offset, _flags)
+#define SD_BUS_METHOD_WITH_NAMES(_member, _signature, _in_names, _result, _out_names, _handler, _flags)   \
+        SD_BUS_METHOD_WITH_NAMES_OFFSET(_member, _signature, _in_names, _result, _out_names, _handler, 0, _flags)
 #define SD_BUS_METHOD(_member, _signature, _result, _handler, _flags)   \
-        SD_BUS_METHOD_WITH_OFFSET(_member, _signature, _result, _handler, 0, _flags)
+        SD_BUS_METHOD_WITH_NAMES_OFFSET(_member, _signature, "", _result, "", _handler, 0, _flags)
 
-#define SD_BUS_SIGNAL(_member, _signature, _flags)                      \
+#define SD_BUS_SIGNAL_WITH_NAMES(_member, _signature, _out_names, _flags)                      \
         {                                                               \
                 .type = _SD_BUS_VTABLE_SIGNAL,                          \
                 .flags = _flags,                                        \
@@ -116,9 +126,12 @@ struct sd_bus_vtable {
                     .signal = {                                         \
                         .member = _member,                              \
                         .signature = _signature,                        \
+                        .names = _out_names,                            \
                     },                                                  \
                 },                                                      \
         }
+#define SD_BUS_SIGNAL(_member, _signature, _flags)   \
+        SD_BUS_SIGNAL_WITH_NAMES(_member, _signature, "", _flags)
 
 #define SD_BUS_PROPERTY(_member, _signature, _get, _offset, _flags)     \
         {                                                               \


### PR DESCRIPTION
Some basic checks below:
```
# systemd-inhibit --what=shutdown --mode=block sleep infinity &
[1] 941
```
```
# systemctl --check-inhibitors=yes reboot
Operation inhibited by "sleep infinity" (PID 941 "systemd-inhibit", user root), reason is "Unknown reason".
User vagrant is logged in on sshd.
Please retry operation after closing inhibitors and logging out other users.
Alternatively, ignore inhibitors and users with 'systemctl reboot -i'.
```

With all these changes from `SD_BUS_METHOD` to `SD_BUS_METHOD_WITH_NAMES`; also `SD_BUS_SIGNAL` has become `SD_BUS_SIGNAL_WITH_NAMES`. It was not obligatory, but it is more consistent now.