### PR TITLE
(#1905582) Set default core ulimit to 0, but keep the hard limit ulimited

### DIFF
--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -52,7 +52,7 @@
 #DefaultLimitFSIZE=
 #DefaultLimitDATA=
 #DefaultLimitSTACK=
-DefaultLimitCORE=0
+DefaultLimitCORE=0:infinity
 #DefaultLimitRSS=
 #DefaultLimitNOFILE=
 #DefaultLimitAS=


### PR DESCRIPTION
so users can change it later.

Follow-up to 830bd662276ee117e65a4b3d541f77e8b172eafd.

rhel-only
Resolves: #1905582