### PR TITLE
(#2007346) busctl: add a timestamp to the output of the busctl monitor command

### DIFF
--- a/src/libsystemd/sd-bus/bus-dump.c
+++ b/src/libsystemd/sd-bus/bus-dump.c
@@ -55,6 +55,15 @@ int bus_message_dump(sd_bus_message *m, FILE *f, unsigned flags) {
                 f = stdout;
 
         if (flags & BUS_MESSAGE_DUMP_WITH_HEADER) {
+                char buf[FORMAT_TIMESTAMP_MAX];
+                const char *p;
+                usec_t ts = m->realtime;
+
+                if (ts == 0)
+                        ts = now(CLOCK_REALTIME);
+
+                p = format_timestamp_us_utc(buf, sizeof(buf), ts);
+
                 fprintf(f,
                         "%s%s%s Type=%s%s%s  Endian=%c  Flags=%u  Version=%u  Priority=%"PRIi64,
                         m->header->type == SD_BUS_MESSAGE_METHOD_ERROR ? ansi_highlight_red() :
@@ -81,6 +90,8 @@ int bus_message_dump(sd_bus_message *m, FILE *f, unsigned flags) {
 
                 if (m->reply_cookie != 0)
                         fprintf(f, "  ReplyCookie=%" PRIu64, m->reply_cookie);
+
+                fprintf(f, "  Timestamp=\"%s\"", strna(p));
 
                 fputs("\n", f);
 


### PR DESCRIPTION
(cherry picked from commit 6fe2a70b9160e35fdeed9d37bd31727c2d46a8b2)
(cherry picked from commit 53673326ea78039b27e1dbd5328a8fe9a1a17445)

Resolves: #2007346