### PR TITLE
(#1991834) udev rules: add rule to create /dev/ptp_hyperv

### DIFF
--- a/rules/50-udev-default.rules.in
+++ b/rules/50-udev-default.rules.in
@@ -83,4 +83,6 @@ KERNEL=="kvm", GROUP="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
 
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"
+
 LABEL="default_end"


### PR DESCRIPTION
As for the KVM case, necessary for network cards with
PTP devices when running a guest on HyperV

(cherry picked from commit 32e868f058da8b90add00b2958c516241c532b70)

Resolves: #1991834