### PR TITLE
(#1961746) pam: do not require a non-expired password for user@.service

### DIFF
--- a/src/login/systemd-user.m4
+++ b/src/login/systemd-user.m4
@@ -2,7 +2,7 @@
 #
 # Used by systemd --user instances.
 
-account required pam_unix.so
+account sufficient pam_unix.so no_pass_expiry
 m4_ifdef(`HAVE_SELINUX',
 session required pam_selinux.so close
 session required pam_selinux.so nottys open


### PR DESCRIPTION
Without this parameter, we would allow user@ to start if the user
has no password (i.e. the password is "locked"). But when the user does have a password,
and it is marked as expired, we would refuse to start the service.
There are other authentication mechanisms and we should not tie this service to
the password state.

The documented way to disable an *account* is to call 'chage -E0'. With a disabled
account, user@.service will still refuse to start:

systemd[16598]: PAM failed: User account has expired
systemd[16598]: PAM failed: User account has expired
systemd[16598]: user@1005.service: Failed to set up PAM session: Operation not permitted
systemd[16598]: user@1005.service: Failed at step PAM spawning /usr/lib/systemd/systemd: Operation not permitted
systemd[1]: user@1005.service: Main process exited, code=exited, status=224/PAM
systemd[1]: user@1005.service: Failed with result 'exit-code'.
systemd[1]: Failed to start user@1005.service.
systemd[1]: Stopping user-runtime-dir@1005.service...

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1961746.

(cherry picked from commit 71889176e4372b443018584c3520c1ff3efe2711)

Resolves: #1961746