### PR TITLE
(#1959150) basic: add vmware hypervisor detection from device-tree

### DIFF
--- a/src/basic/virt.c
+++ b/src/basic/virt.c
@@ -122,6 +122,8 @@ static int detect_vm_device_tree(void) {
                 return VIRTUALIZATION_KVM;
         else if (strstr(hvtype, "xen"))
                 return VIRTUALIZATION_XEN;
+        else if (strstr(hvtype, "vmware"))
+                return VIRTUALIZATION_VMWARE;
         else
                 return VIRTUALIZATION_VM_OTHER;
 #else


### PR DESCRIPTION
Allow ConditionVirtualization=vmware to work on ESXi on arm VMs
using device-tree.

(cherry picked from commit 4d4ac92c928fcbc60b85fcbf8370af3883ee63db)

Resolves: #1959150