### PR TITLE
(#2018024) rpm: Fix typo in %_environmentdir

### DIFF
--- a/src/core/macros.systemd.in
+++ b/src/core/macros.systemd.in
@@ -28,7 +28,7 @@
 
 # Because we had one release with a typo...
 # This is temporary (Remove after systemd 240 is released)
-%_environmnentdir %_environmentdir
+%_environmnentdir %{warn:Use %%_environmentdir instead}%_environmentdir
 
 %systemd_requires \
 Requires(post): systemd \

--- a/src/core/macros.systemd.in
+++ b/src/core/macros.systemd.in
@@ -18,7 +18,7 @@
 %_sysctldir @sysctldir@
 %_sysusersdir @sysusersdir@
 %_tmpfilesdir @tmpfilesdir@
-%_environmnentdir @environmentdir@
+%_environmentdir @environmentdir@
 %_modulesloaddir @modulesloaddir@
 %_modprobedir @modprobedir@
 %_systemdgeneratordir @systemgeneratordir@

--- a/src/core/macros.systemd.in
+++ b/src/core/macros.systemd.in
@@ -26,6 +26,10 @@
 %_systemd_system_env_generator_dir @systemenvgeneratordir@
 %_systemd_user_env_generator_dir @userenvgeneratordir@
 
+# Because we had one release with a typo...
+# This is temporary (Remove after systemd 240 is released)
+%_environmnentdir %_environmentdir
+
 %systemd_requires \
 Requires(post): systemd \
 Requires(preun): systemd \


### PR DESCRIPTION
This is a backport of upstream commits to fix the misspelled %_environmentdir macro.