### PR TITLE
(#2017033) meson: do not fail if rsync is not installed with meson 0.57.2

### DIFF
--- a/man/meson.build
+++ b/man/meson.build
@@ -178,17 +178,20 @@ html = custom_target(
         depends : html_pages,
         command : ['echo'])
 
-run_target(
-        'doc-sync',
-        depends : man_pages + html_pages,
-        command : ['rsync', '-rlv',
-                   '--delete-excluded',
-                   '--include=man',
-                   '--include=*.html',
-                   '--exclude=*',
-                   '--omit-dir-times',
-                   meson.current_build_dir(),
-                   get_option('www-target')])
+rsync = find_program('rsync', required : false)
+if rsync.found()
+        run_target(
+                'doc-sync',
+                depends : man_pages + html_pages,
+                command : [rsync, '-rlv',
+                           '--delete-excluded',
+                           '--include=man',
+                           '--include=*.html',
+                           '--exclude=*',
+                           '--omit-dir-times',
+                           meson.current_build_dir(),
+                           get_option('www-target')])
+endif
 
 ############################################################
 


### PR DESCRIPTION
https://github.com/mesonbuild/meson/issues/8641

Our CI started to fail. Even if the change is reverted in meson,
we need a quick workaround here.

(cherry picked from commit 7c5fd25119a495009ea62f79e5daec34cc464628)

Related: #2017033