### PR TITLE
(#1860899) core: return true from cg_is_empty* on ENOENT

### DIFF
--- a/src/basic/cgroup-util.c
+++ b/src/basic/cgroup-util.c
@@ -1177,7 +1177,7 @@ int cg_is_empty(const char *controller, const char *path) {
 
         r = cg_enumerate_processes(controller, path, &f);
         if (r == -ENOENT)
-                return 1;
+                return true;
         if (r < 0)
                 return r;
 
@@ -1207,6 +1207,8 @@ int cg_is_empty_recursive(const char *controller, const char *path) {
                  * via the "populated" attribute of "cgroup.events". */
 
                 r = cg_read_event(controller, path, "populated", &t);
+                if (r == -ENOENT)
+                        return true;
                 if (r < 0)
                         return r;
 
@@ -1221,7 +1223,7 @@ int cg_is_empty_recursive(const char *controller, const char *path) {
 
                 r = cg_enumerate_subgroups(controller, path, &d);
                 if (r == -ENOENT)
-                        return 1;
+                        return true;
                 if (r < 0)
                         return r;
 


### PR DESCRIPTION
(cherry picked from commit 1bcf3fc6c57d92927b96cad8c739099b4ceae236)

Related: #1860899

---

Forgotten(?) commit from https://github.com/systemd/systemd/pull/10428/ (follow-up to #213). Without this commit some tests (and most likely even machines) get stuck during shutdown with unified cgroups.

@dtardon @jamacku PTAL.