### PR TITLE
(#2036853) Fix unit table overflow by mounts, resulting in "Argument list too long" when trying to start a unit

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1621,12 +1621,10 @@ static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
         if (r < 0)
                 return log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
 
-        r = 0;
         for (;;) {
                 struct libmnt_fs *fs;
                 const char *device, *path, *options, *fstype;
                 _cleanup_free_ char *d = NULL, *p = NULL;
-                int k;
 
                 r = mnt_table_next_fs(table, iter, &fs);
                 if (r == 1)
@@ -1650,12 +1648,10 @@ static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
 
                 device_found_node(m, d, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
 
-                k = mount_setup_unit(m, d, p, options, fstype, set_flags);
-                if (r == 0 && k < 0)
-                        r = k;
+                (void) mount_setup_unit(m, d, p, options, fstype, set_flags);
         }
 
-        return r;
+        return 0;
 }
 
 static void mount_shutdown(Manager *m) {


### PR DESCRIPTION
This is a backport of https://github.com/systemd/systemd/pull/10980 (commit https://github.com/systemd/systemd/pull/10980/commits/ba0d56f55f2073164799be714b5bd1aad94d059a only) to address issues like https://github.com/systemd/systemd/issues/10874. The backport was almost clean, except for
* a trivial conflict in src/core/mount.c, function mount_load_proc_self_mountinfo, due to local commit ca634baa10e (that changed variable names and removed `= 0` from `int r`);
* due to the same commit, `int k` is no longer used, so I had to remove it.

~~This also backports https://github.com/systemd/systemd/pull/15222 as it helps a lot to figure out what is going on. This is not required and can be removed.~~

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=2028153 (a non-parse-able mount in mountinfo resulted in piling up inactive mount units, up to `MANAGER_MAX_NAMES`, after which it becomes impossible to start any units).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2036853