### PR TITLE
(#2039327) mount: don't propagate errors from mount_setup_unit() further up

### DIFF
--- a/.github/workflows/unit_tests.sh
+++ b/.github/workflows/unit_tests.sh
@@ -131,7 +131,7 @@ for phase in "${PHASES[@]}"; do
             # Pull a Docker image and start a new container
             docker pull quay.io/centos/centos:$CENTOS_RELEASE
             info "Starting container $CONT_NAME"
-            $DOCKER_RUN -v $REPO_ROOT:/build:rw \
+            $DOCKER_RUN -v $REPO_ROOT:/build:rw -e GITHUB_ACTIONS="$GITHUB_ACTIONS" \
                         -w /build --privileged=true --name $CONT_NAME \
                         -dit --net=host quay.io/centos/centos:$CENTOS_RELEASE /sbin/init
 

--- a/src/basic/macro.h
+++ b/src/basic/macro.h
@@ -55,6 +55,19 @@
 #  endif
 #endif
 
+#if !defined(HAS_FEATURE_ADDRESS_SANITIZER)
+#  ifdef __SANITIZE_ADDRESS__
+#      define HAS_FEATURE_ADDRESS_SANITIZER 1
+#  elif defined(__has_feature)
+#    if __has_feature(address_sanitizer)
+#      define HAS_FEATURE_ADDRESS_SANITIZER 1
+#    endif
+#  endif
+#  if !defined(HAS_FEATURE_ADDRESS_SANITIZER)
+#    define HAS_FEATURE_ADDRESS_SANITIZER 0
+#  endif
+#endif
+
 /* Temporarily disable some warnings */
 #define DISABLE_WARNING_DECLARATION_AFTER_STATEMENT                     \
         _Pragma("GCC diagnostic push");                                 \

--- a/src/basic/string-util.h
+++ b/src/basic/string-util.h
@@ -32,6 +32,12 @@ static inline bool streq_ptr(const char *a, const char *b) {
         return strcmp_ptr(a, b) == 0;
 }
 
+static inline char* strstr_ptr(const char *haystack, const char *needle) {
+        if (!haystack || !needle)
+                return NULL;
+        return strstr(haystack, needle);
+}
+
 static inline const char* strempty(const char *s) {
         return s ?: "";
 }

--- a/src/basic/strv.h
+++ b/src/basic/strv.h
@@ -148,17 +148,10 @@ void strv_print(char **l);
                 _found;                                         \
         })
 
-#define FOREACH_STRING(x, ...)                               \
-        for (char **_l = ({                                  \
-                char **_ll = STRV_MAKE(__VA_ARGS__);         \
-                x = _ll ? _ll[0] : NULL;                     \
-                _ll;                                         \
-        });                                                  \
-        _l && *_l;                                           \
-        x = ({                                               \
-                _l ++;                                       \
-                _l[0];                                       \
-        }))
+#define FOREACH_STRING(x, y, ...)                                       \
+        for (char **_l = STRV_MAKE(({ x = y; }), ##__VA_ARGS__);        \
+             x;                                                         \
+             x = *(++_l))
 
 char **strv_reverse(char **l);
 char **strv_shell_escape(char **l, const char *bad);

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1621,12 +1621,10 @@ static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
         if (r < 0)
                 return log_error_errno(r, "Failed to parse /proc/self/mountinfo: %m");
 
-        r = 0;
         for (;;) {
                 struct libmnt_fs *fs;
                 const char *device, *path, *options, *fstype;
                 _cleanup_free_ char *d = NULL, *p = NULL;
-                int k;
 
                 r = mnt_table_next_fs(table, iter, &fs);
                 if (r == 1)
@@ -1650,12 +1648,10 @@ static int mount_load_proc_self_mountinfo(Manager *m, bool set_flags) {
 
                 device_found_node(m, d, DEVICE_FOUND_MOUNT, DEVICE_FOUND_MOUNT);
 
-                k = mount_setup_unit(m, d, p, options, fstype, set_flags);
-                if (r == 0 && k < 0)
-                        r = k;
+                (void) mount_setup_unit(m, d, p, options, fstype, set_flags);
         }
 
-        return r;
+        return 0;
 }
 
 static void mount_shutdown(Manager *m) {

--- a/src/shared/tests.c
+++ b/src/shared/tests.c
@@ -7,7 +7,9 @@
 #include <util.h>
 
 #include "tests.h"
+#include "env-util.h"
 #include "path-util.h"
+#include "strv.h"
 
 char* setup_fake_runtime_dir(void) {
         char t[] = "/tmp/fake-xdg-runtime-XXXXXX", *p;
@@ -74,4 +76,44 @@ void test_setup_logging(int level) {
         log_set_max_level(level);
         log_parse_environment();
         log_open();
+}
+
+const char *ci_environment(void) {
+        /* We return a string because we might want to provide multiple bits of information later on: not
+         * just the general CI environment type, but also whether we're sanitizing or not, etc. The caller is
+         * expected to use strstr on the returned value. */
+        static const char *ans = (void*) UINTPTR_MAX;
+        const char *p;
+        int r;
+
+        if (ans != (void*) UINTPTR_MAX)
+                return ans;
+
+        /* We allow specifying the environment with $CITYPE. Nobody uses this so far, but we are ready. */
+        p = getenv("CITYPE");
+        if (!isempty(p))
+                return (ans = p);
+
+        if (getenv_bool("TRAVIS") > 0)
+                return (ans = "travis");
+        if (getenv_bool("SEMAPHORE") > 0)
+                return (ans = "semaphore");
+        if (getenv_bool("GITHUB_ACTIONS") > 0)
+                return (ans = "github-actions");
+        if (getenv("AUTOPKGTEST_ARTIFACTS") || getenv("AUTOPKGTEST_TMP"))
+                return (ans = "autopkgtest");
+
+        FOREACH_STRING(p, "CI", "CONTINOUS_INTEGRATION") {
+                /* Those vars are booleans according to Semaphore and Travis docs:
+                 * https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+                 * https://docs.semaphoreci.com/ci-cd-environment/environment-variables/#ci
+                 */
+                r = getenv_bool(p);
+                if (r > 0)
+                        return (ans = "unknown"); /* Some other unknown thing */
+                if (r == 0)
+                        return (ans = NULL);
+        }
+
+        return (ans = NULL);
 }

--- a/src/shared/tests.h
+++ b/src/shared/tests.h
@@ -5,3 +5,6 @@ char* setup_fake_runtime_dir(void);
 bool test_is_running_from_builddir(char **exedir);
 const char* get_testdata_dir(void);
 void test_setup_logging(int level);
+
+/* Provide a convenient way to check if we're running in CI. */
+const char *ci_environment(void);

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -7011,7 +7011,8 @@ static int run_editor(char **paths) {
         if (r == 0) {
                 const char **args;
                 char *editor, **editor_args = NULL;
-                char **tmp_path, **original_path, *p;
+                char **tmp_path, **original_path;
+                const char *p;
                 size_t n_editor_args = 0, i = 1;
                 size_t argc;
 

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -146,7 +146,7 @@ invalid:
 }
 
 static bool is_inaccessible_available(void) {
-        char *p;
+        const char *p;
 
         FOREACH_STRING(p,
                 "/run/systemd/inaccessible/reg",

--- a/test/TEST-47-ISSUE-14566/testsuite.sh
+++ b/test/TEST-47-ISSUE-14566/testsuite.sh
@@ -6,11 +6,13 @@ systemd-analyze log-level debug
 systemd-analyze log-target console
 
 systemctl start issue_14566_test
+sleep 4
 systemctl status issue_14566_test
 
 leaked_pid=$(cat /leakedtestpid)
 
 systemctl stop issue_14566_test
+sleep 4
 
 # Leaked PID will still be around if we're buggy.
 # I personally prefer to see 42.


### PR DESCRIPTION
If we can't process a specific line in /proc/self/mountinfo we should
log about it (which we do), but this should not affect other lines, nor
further processing of mount units. Let's keep these failures local.

Fixes: #10874

(cherry picked from commit ba0d56f55f2073164799be714b5bd1aad94d059a)

Resolves: #2039327