### PR TITLE
(#2042439) shared/install: Preserve escape characters for escaped unit names

### DIFF
--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2774,7 +2774,7 @@ static int split_pattern_into_name_and_instances(const char *pattern, char **out
         assert(out_instances);
         assert(out_unit_name);
 
-        r = extract_first_word(&pattern, &unit_name, NULL, 0);
+        r = extract_first_word(&pattern, &unit_name, NULL, EXTRACT_RETAIN_ESCAPE);
         if (r < 0)
                 return r;
 


### PR DESCRIPTION
Since switching to extract_first_word with no flags for parsing
unit names in 4c9565eea534cd233a913c8c21f7920dba229743, escape
characters will be stripped from escaped unit names such as
"mnt-persistent\x2dvolume.mount" resulting in the unit not being
configured as defined.  Preserve escape characters again for
compatibility with existing preset definitions.

(cherry picked from commit 82bd4da71e9cdd5a2e9266332f5a7399845e31f6)

Resolves: #2042439