### PR TITLE
(#2045307) core: make sure we don't get confused when setting TERM for a tty fd

### DIFF
--- a/src/core/execute.c
+++ b/src/core/execute.c
@@ -1709,12 +1709,13 @@ static int build_environment(
 
                 tty_path = exec_context_tty_path(c);
 
-                /* If we are forked off PID 1 and we are supposed to operate on /dev/console, then let's try to inherit
-                 * the $TERM set for PID 1. This is useful for containers so that the $TERM the container manager
-                 * passes to PID 1 ends up all the way in the console login shown. */
+                /* If we are forked off PID 1 and we are supposed to operate on /dev/console, then let's try
+                 * to inherit the $TERM set for PID 1. This is useful for containers so that the $TERM the
+                 * container manager passes to PID 1 ends up all the way in the console login shown. */
 
-                if (path_equal(tty_path, "/dev/console") && getppid() == 1)
+                if (path_equal_ptr(tty_path, "/dev/console") && getppid() == 1)
                         term = getenv("TERM");
+
                 if (!term)
                         term = default_term_for_tty(tty_path);
 


### PR DESCRIPTION
Fixes: #15344
(cherry picked from commit e8cf09b2a2ad0d48e5493050d54251d5f512d9b6)

Resolves: #2045307