### PR TITLE
(#2017035) test: adapt to the new capsh format

### DIFF
--- a/test/test-execute/exec-capabilityboundingset-invert.service
+++ b/test/test-execute/exec-capabilityboundingset-invert.service
@@ -2,7 +2,7 @@
 Description=Test for CapabilityBoundingSet
 
 [Service]
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep "^Bounding set .*cap_chown"'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep "^Bounding set .*cap_chown"'
 Type=oneshot
 CapabilityBoundingSet=~CAP_CHOWN

--- a/test/test-execute/exec-capabilityboundingset-invert.service
+++ b/test/test-execute/exec-capabilityboundingset-invert.service
@@ -2,6 +2,7 @@
 Description=Test for CapabilityBoundingSet
 
 [Service]
-ExecStart=/bin/sh -x -c '! capsh --print | grep "^Bounding set .*cap_chown"'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep "^Bounding set .*cap_chown"'
 Type=oneshot
 CapabilityBoundingSet=~CAP_CHOWN

--- a/test/test-execute/exec-privatedevices-no-capability-mknod.service
+++ b/test/test-execute/exec-privatedevices-no-capability-mknod.service
@@ -3,5 +3,6 @@ Description=Test CAP_MKNOD capability for PrivateDevices=no
 
 [Service]
 PrivateDevices=no
-ExecStart=/bin/sh -x -c 'capsh --print | grep cap_mknod'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c 'capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_mknod'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-no-capability-mknod.service
+++ b/test/test-execute/exec-privatedevices-no-capability-mknod.service
@@ -3,6 +3,6 @@ Description=Test CAP_MKNOD capability for PrivateDevices=no
 
 [Service]
 PrivateDevices=no
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c 'capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_mknod'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c 'capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep cap_mknod'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-no-capability-sys-rawio.service
+++ b/test/test-execute/exec-privatedevices-no-capability-sys-rawio.service
@@ -3,5 +3,6 @@ Description=Test CAP_SYS_RAWIO capability for PrivateDevices=no
 
 [Service]
 PrivateDevices=no
-ExecStart=/bin/sh -x -c 'capsh --print | grep cap_sys_rawio'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c 'capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_rawio'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-no-capability-sys-rawio.service
+++ b/test/test-execute/exec-privatedevices-no-capability-sys-rawio.service
@@ -3,6 +3,6 @@ Description=Test CAP_SYS_RAWIO capability for PrivateDevices=no
 
 [Service]
 PrivateDevices=no
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c 'capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_rawio'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c 'capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep cap_sys_rawio'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-yes-capability-mknod.service
+++ b/test/test-execute/exec-privatedevices-yes-capability-mknod.service
@@ -3,5 +3,6 @@ Description=Test CAP_MKNOD capability for PrivateDevices=yes
 
 [Service]
 PrivateDevices=yes
-ExecStart=/bin/sh -x -c '! capsh --print | grep cap_mknod'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_mknod'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-yes-capability-mknod.service
+++ b/test/test-execute/exec-privatedevices-yes-capability-mknod.service
@@ -3,6 +3,6 @@ Description=Test CAP_MKNOD capability for PrivateDevices=yes
 
 [Service]
 PrivateDevices=yes
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_mknod'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep cap_mknod'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-yes-capability-sys-rawio.service
+++ b/test/test-execute/exec-privatedevices-yes-capability-sys-rawio.service
@@ -3,5 +3,6 @@ Description=Test CAP_SYS_RAWIO capability for PrivateDevices=yes
 
 [Service]
 PrivateDevices=yes
-ExecStart=/bin/sh -x -c '! capsh --print | grep cap_sys_rawio'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_rawio'
 Type=oneshot

--- a/test/test-execute/exec-privatedevices-yes-capability-sys-rawio.service
+++ b/test/test-execute/exec-privatedevices-yes-capability-sys-rawio.service
@@ -3,6 +3,6 @@ Description=Test CAP_SYS_RAWIO capability for PrivateDevices=yes
 
 [Service]
 PrivateDevices=yes
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_rawio'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep cap_sys_rawio'
 Type=oneshot

--- a/test/test-execute/exec-protectkernelmodules-no-capabilities.service
+++ b/test/test-execute/exec-protectkernelmodules-no-capabilities.service
@@ -3,5 +3,6 @@ Description=Test CAP_SYS_MODULE ProtectKernelModules=no
 
 [Service]
 ProtectKernelModules=no
-ExecStart=/bin/sh -x -c 'capsh --print | grep cap_sys_module'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c 'capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_module'
 Type=oneshot

--- a/test/test-execute/exec-protectkernelmodules-no-capabilities.service
+++ b/test/test-execute/exec-protectkernelmodules-no-capabilities.service
@@ -3,6 +3,6 @@ Description=Test CAP_SYS_MODULE ProtectKernelModules=no
 
 [Service]
 ProtectKernelModules=no
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c 'capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_module'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c 'capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep cap_sys_module'
 Type=oneshot

--- a/test/test-execute/exec-protectkernelmodules-yes-capabilities.service
+++ b/test/test-execute/exec-protectkernelmodules-yes-capabilities.service
@@ -3,5 +3,6 @@ Description=Test CAP_SYS_MODULE for ProtectKernelModules=yes
 
 [Service]
 ProtectKernelModules=yes
-ExecStart=/bin/sh -x -c '! capsh --print | grep cap_sys_module'
+# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_module'
 Type=oneshot

--- a/test/test-execute/exec-protectkernelmodules-yes-capabilities.service
+++ b/test/test-execute/exec-protectkernelmodules-yes-capabilities.service
@@ -3,6 +3,6 @@ Description=Test CAP_SYS_MODULE for ProtectKernelModules=yes
 
 [Service]
 ProtectKernelModules=yes
-# sed: remove dropped capabilities (cap_xxx-[epi]) from the output
-ExecStart=/bin/sh -x -c '! capsh --print | sed -r "s/[^ ]+?\-[epi]+//g" | grep cap_sys_module'
+# sed: remove dropped (cap_xxx-[epi]) and IAB capabilities from the output
+ExecStart=/bin/sh -x -c '! capsh --print | sed -re "s/[^ ]+?\-[epi]+//g" -e '/IAB/d' | grep cap_sys_module'
 Type=oneshot


### PR DESCRIPTION
Since libcap v2.29 the format of cap_to_text() has been changed which
makes certain `test-execute` subtest fail. Let's remove the offending
part of the output (dropped capabilities) to make it compatible with
both the old and the new libcap.

(cherry picked from commit 9569e385036c05c0bf9fbccdbf3d131161398e2e)

Related: #2017035