### PR TITLE
(#2017035) ci: drop CentOS 8 CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [centos8, stream8]
+        image: [stream8]
         phase: [GCC, GCC_ASAN]
     env:
       CONT_NAME: "systemd-centos8-ci"


### PR DESCRIPTION
since it went EOL and we should use only Stream 8 from now on.

rhel-only
Related: #2017035