### PR TITLE
(#2054264) seccomp: allow turning off of seccomp filtering via env var

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [centos8, stream8]
+        image: [stream8]
         phase: [GCC, GCC_ASAN]
     env:
       CONT_NAME: "systemd-centos8-ci"

--- a/doc/ENVIRONMENT.md
+++ b/doc/ENVIRONMENT.md
@@ -117,3 +117,6 @@ systemd-sulogin-shell:
 * `$SYSTEMD_SULOGIN_FORCE=1` — This skips asking for the root password if the
   root password is not available (such as when the root account is locked).
   See `sulogin(8)` for more details.
+
+* `$SYSTEMD_SECCOMP=0` – if set, seccomp filters will not be enforced, even if
+  support for it is compiled in and available in the kernel.

--- a/src/nspawn/nspawn-seccomp.c
+++ b/src/nspawn/nspawn-seccomp.c
@@ -172,7 +172,7 @@ int setup_seccomp(uint64_t cap_list_retain, char **syscall_whitelist, char **sys
         int r;
 
         if (!is_seccomp_available()) {
-                log_debug("SECCOMP features not detected in the kernel, disabling SECCOMP filterering");
+                log_debug("SECCOMP features not detected in the kernel or disabled at runtime, disabling SECCOMP filtering");
                 return 0;
         }
 


### PR DESCRIPTION
Fixes: #17504

(While we are it, also move $SYSTEMD_SECCOMP_LOG= env var description
into the right document section)

Also suggested in: https://github.com/systemd/systemd/issues/17245#issuecomment-704773603

(cherry picked from commit ce8f6d478e3f6c6a313fb19615aa5029bb18f86d)

Resolves: #2054264