### PR TITLE
(#2056527) core: unset HOME=/ that the kernel gives us

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1307,6 +1307,11 @@ static int fixup_environment(void) {
         if (setenv("TERM", t, 1) < 0)
                 return -errno;
 
+        /* The kernels sets HOME=/ for init. Let's undo this. */
+        if (path_equal_ptr(getenv("HOME"), "/") &&
+            unsetenv("HOME") < 0)
+                log_warning_errno(errno, "Failed to unset $HOME: %m");
+
         return 0;
 }
 


### PR DESCRIPTION
Partially fixes #12389.

%h would return "/" in a machine, but "/root" in a container. Let's fix
this by resetting $HOME to the expected value.

(cherry picked from commit 9d48671c62de133a2b9fe7c31e70c0ff8e68f2db)

Resolves: #2056527