### PR TITLE
(#1948480) unit: don't emit PropertiesChanged signal if adding a dependency to a…

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2818,6 +2818,9 @@ int unit_add_dependency(
         };
         Unit *original_u = u, *original_other = other;
         int r;
+        /* Helper to know whether sending a notification is necessary or not:
+         * if the dependency is already there, no need to notify! */
+        bool noop = true;
 
         assert(u);
         assert(d >= 0 && d < _UNIT_DEPENDENCY_MAX);
@@ -2842,24 +2845,33 @@ int unit_add_dependency(
         r = unit_add_dependency_hashmap(u->dependencies + d, other, mask, 0);
         if (r < 0)
                 return r;
+        else if (r > 0)
+                noop = false;
 
         if (inverse_table[d] != _UNIT_DEPENDENCY_INVALID && inverse_table[d] != d) {
                 r = unit_add_dependency_hashmap(other->dependencies + inverse_table[d], u, 0, mask);
                 if (r < 0)
                         return r;
+                else if (r > 0)
+                        noop = false;
         }
 
         if (add_reference) {
                 r = unit_add_dependency_hashmap(u->dependencies + UNIT_REFERENCES, other, mask, 0);
                 if (r < 0)
                         return r;
+                else if (r > 0)
+                        noop = false;
 
                 r = unit_add_dependency_hashmap(other->dependencies + UNIT_REFERENCED_BY, u, 0, mask);
                 if (r < 0)
                         return r;
+                else if (r > 0)
+                        noop = false;
         }
 
-        unit_add_to_dbus_queue(u);
+        if (!noop)
+                unit_add_to_dbus_queue(u);
         return 0;
 }
 


### PR DESCRIPTION
… unit is a no-op

(cherry picked from commit 5177cb0a9add4ae568cff6e6f7c2b3c77760c343)

Resolves: #1948480