### PR TITLE
(#2087152) ci(Mergify): Add rules for `needs-ci` label management

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,48 @@
+# doc: https://docs.mergify.com
+---
+
+pull_request_rules:
+  - name: Add `needs-ci` label on CI fail
+    conditions:
+      - or:
+        # Unit tests
+        - -check-success=build (stream8, GCC)
+        - -check-success=build (stream8, GCC_ASAN)
+        # CentOS Stream CI
+        - -check-success=CentOS CI (CentOS Stream 8)
+        # LGTM
+        - and:
+          - "-check-success=LGTM analysis: JavaScript"
+          - "-check-neutral=LGTM analysis: JavaScript"
+        - and:
+          - "-check-success=LGTM analysis: Python"
+          - "-check-neutral=LGTM analysis: Python"
+        - and:    
+          - "-check-success=LGTM analysis: C/C++"
+          - "-check-neutral=LGTM analysis: C/C++"
+    actions:
+      label:
+        add:
+          - needs-ci
+
+  - name: Remove `needs-ci` label on CI success
+    conditions:
+      # Unit tests
+      - check-success=build (stream8, GCC)
+      - check-success=build (stream8, GCC_ASAN)
+      # CentOS Stream CI
+      - check-success=CentOS CI (CentOS Stream 8)
+      # LGTM
+      - or:
+        - "check-success=LGTM analysis: JavaScript"
+        - "check-neutral=LGTM analysis: JavaScript"
+      - or:
+        - "check-success=LGTM analysis: Python"
+        - "check-neutral=LGTM analysis: Python"
+      - or:    
+        - "check-success=LGTM analysis: C/C++"
+        - "check-neutral=LGTM analysis: C/C++"
+    actions:
+      label:
+        remove:
+          - needs-ci


### PR DESCRIPTION
Add rules for `needs-ci` label management

RHEL-only

Related: #2087152

---

This change has been made by @jamacku from https://mergify.com config editor.