### PR TITLE
(#2097336) unit: check for mount rate limiting before checking active state

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1999,9 +1999,6 @@ static int mount_can_start(Unit *u) {
 
         assert(m);
 
-        if (sd_event_source_is_ratelimited(u->manager->mount_event_source))
-                return -EAGAIN;
-
         r = unit_test_start_limit(u);
         if (r < 0) {
                 mount_enter_dead(m, MOUNT_FAILURE_START_LIMIT_HIT);

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -1729,6 +1729,10 @@ int unit_start(Unit *u) {
 
         assert(u);
 
+        /* Let's hold off running start jobs for mount units when /proc/self/mountinfo monitor is rate limited. */
+        if (u->type == UNIT_MOUNT && sd_event_source_is_ratelimited(u->manager->mount_event_source))
+                return -EAGAIN;
+
         /* If this is already started, then this will succeed. Note that this will even succeed if this unit
          * is not startable by the user. This is relied on to detect when we need to wait for units and when
          * waiting is finished. */


### PR DESCRIPTION
Having this check as part of mount_can_start() is too late because
UNIT(u)->can_start() virtual method is called after checking the active
state of unit in unit_start().

We need to hold off running mount start jobs when /p/s/mountinfo monitor
is rate limited even when given mount unit is already active.

Fixes #20329

(cherry picked from commit b161bc394b2cc8b271dda9208e310cc2af0cc29d)

Resolves: #2097336