### PR TITLE
(#2115396) sd-event: don't invalidate source type on disconnect

### DIFF
--- a/src/libsystemd/sd-event/sd-event.c
+++ b/src/libsystemd/sd-event/sd-event.c
@@ -1104,10 +1104,12 @@ static void source_disconnect(sd_event_source *s) {
 
         event = s->event;
 
-        s->type = _SOURCE_EVENT_SOURCE_TYPE_INVALID;
         s->event = NULL;
         LIST_REMOVE(sources, event->sources, s);
         event->n_sources--;
+
+        /* Note that we don't invalidate the type here, since we still need it in order to close the fd or
+         * pidfd associated with this event source, which we'll do only on source_free(). */
 
         if (!s->floating)
                 sd_event_unref(event);


### PR DESCRIPTION
This fixes fd closing if fd ownership is requested.

(cherry picked from commit f59825595182d70b9ead238d1e885d0db99cc201)

Resolves: #2115396