### PR TITLE
(#2127170) core: move reset_arguments() to the end of main's finish

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -2631,7 +2631,6 @@ finish:
                 m = manager_free(m);
         }
 
-        reset_arguments();
         mac_selinux_finish();
 
         if (reexecute)
@@ -2656,6 +2655,7 @@ finish:
                  * in become_shutdown() so normally we cannot free them yet. */
                 watchdog_free_device();
                 arg_watchdog_device = mfree(arg_watchdog_device);
+                reset_arguments();
                 return retval;
         }
 #endif
@@ -2677,5 +2677,6 @@ finish:
                 freeze_or_reboot();
         }
 
+        reset_arguments();
         return retval;
 }


### PR DESCRIPTION
Fixes #16991

fb39af4ce42d7ef9af63009f271f404038703704 replaced `free_arguments()` with `reset_arguments()`, which frees arg_* variables as before, but also resets all of them to the default values. `reset_arguments()` was positioned in such a way that it overrode some arg_* values still in use at shutdown.

To avoid further unintentional resets, I moved `reset_arguments()` right before the return, when nothing else will be using the arg_* variables.

(cherry picked from commit 7d9eea2bd3d4f83668c7a78754d201b226acbf1e)

Resolves: [#2127170](https://bugzilla.redhat.com/show_bug.cgi?id=2127170)