### PR TITLE
(#2139391) time-util: fix buffer-over-run

### DIFF
--- a/src/basic/time-util.c
+++ b/src/basic/time-util.c
@@ -515,7 +515,7 @@ char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
                         t = b;
                 }
 
-                n = MIN((size_t) k, l);
+                n = MIN((size_t) k, l-1);
 
                 l -= n;
                 p += n;

--- a/src/test/test-time-util.c
+++ b/src/test/test-time-util.c
@@ -187,6 +187,11 @@ static void test_format_timespan(usec_t accuracy) {
         test_format_timespan_one(500 * USEC_PER_MSEC, accuracy);
         test_format_timespan_one(9*USEC_PER_YEAR/5 - 23, accuracy);
         test_format_timespan_one(USEC_INFINITY, accuracy);
+
+        /* See issue #23928. */
+        _cleanup_free_ char *buf;
+        assert_se(buf = new(char, 5));
+        assert_se(buf == format_timespan(buf, 5, 100005, 1000));
 }
 
 static void test_timezone_is_valid(void) {


### PR DESCRIPTION
Fixes #23928.

(cherry picked from commit 9102c625a673a3246d7e73d8737f3494446bad4e)

Resolves: [#2139391](https://bugzilla.redhat.com/show_bug.cgi?id=2139391)