### PR TITLE
(#2043524) device: drop refuse_after

### DIFF
--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -2841,8 +2841,9 @@ int unit_add_dependency(
                 return 0;
         }
 
-        if ((d == UNIT_BEFORE && other->type == UNIT_DEVICE) ||
-            (d == UNIT_AFTER && u->type == UNIT_DEVICE)) {
+        /* Note that ordering a device unit after a unit is permitted since it
+         * allows to start its job running timeout at a specific time. */
+        if (d == UNIT_BEFORE && other->type == UNIT_DEVICE) {
                 log_unit_warning(u, "Dependency Before=%s ignored (.device units cannot be delayed)", other->id);
                 return 0;
         }


### PR DESCRIPTION
Scheduling devices after a given unit can be useful to start device *jobs* at a specific time in the transaction, see commit 4195077ab4c823c.

This (hidden) change was introduced by commit eef85c4a3f8054d2.

(cherry picked from commit b862c25716520d9381d5a841dba0f0c14e9c970a)

[dtardon: This picks just the minimal relevant change from c80a9a33d04fb4381327a69ce929c94a9f1d0e6c and
b862c25716520d9381d5a841dba0f0c14e9c970a]

Resolves: [#2043524](https://bugzilla.redhat.com/show_bug.cgi?id=2043524)