### PR TITLE
(#2143103) basic: recognize pdfs filesystem as a network filesystem

### DIFF
--- a/src/basic/mount-util.c
+++ b/src/basic/mount-util.c
@@ -615,7 +615,8 @@ bool fstype_is_network(const char *fstype) {
                           "glusterfs",
                           "pvfs2", /* OrangeFS */
                           "ocfs2",
-                          "lustre");
+                          "lustre",
+                          "pdfs");
 }
 
 bool fstype_is_api_vfs(const char *fstype) {


### PR DESCRIPTION
Fujitsu advises their users to always use _netdev mount option with pdfs mounts. Hence it makes sense to simply consider pdfs mounts as network filesystem mounts.

https://software.fujitsu.com/jp/manual/manualfiles/m130027/j2ul1563/02enz200/j1563-02-06-02-02.html

RHEL-only

Resolves: #2143103