### PR TITLE
(#2123927) core: give a nicer error message on invalid aliases

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -2027,6 +2027,16 @@ static int install_error(
                                               "Refusing to operate on linked unit file %s", changes[i].path);
                         goto found;
 
+                case -EXDEV:
+                        if (changes[i].source)
+                                r = sd_bus_error_setf(error, BUS_ERROR_BAD_UNIT_SETTING,
+                                                      "Cannot alias %s as %s.",
+                                                      changes[i].source, changes[i].path);
+                        else
+                                r = sd_bus_error_setf(error, BUS_ERROR_BAD_UNIT_SETTING,
+                                                      "Invalid unit reference %s.", changes[i].path);
+                        goto found;
+
                 case -ENOENT:
                         r = sd_bus_error_setf(error, BUS_ERROR_NO_SUCH_UNIT, "Unit file %s does not exist.", changes[i].path);
                         goto found;


### PR DESCRIPTION
(cherry picked from commit c89d0c3b0567eb8fdf0b06a27f46c64245d2f0a4)

Resolves: #2123927