### PR TITLE
(#1861836) pam: add a call to pam_namespace

### DIFF
--- a/src/login/systemd-user.m4
+++ b/src/login/systemd-user.m4
@@ -9,4 +9,5 @@ session required pam_selinux.so nottys open
 )m4_dnl
 session required pam_loginuid.so
 session optional pam_keyinit.so force revoke
+session required pam_namespace.so
 session optional pam_systemd.so


### PR DESCRIPTION
A call to pam_namespace is required so that children of user@.service end up in a namespace as expected. pam_namespace gets called as part of the stack that creates a session (login, sshd, gdm, etc.) and those processes end up in a namespace, but it also needs to be called from our stack which is parallel and descends from pid1 itself.

The call to pam_namespace is similar to the call to pam_keyinit that was added in ab79099d1684457d040ee7c28b2012e8c1ea9a4f. The pam stack for user@.service creates a new session which is disconnected from the parent environment. Both calls are not suitable for inclusion in the shared part of the stack (e.g. @system-auth on Fedora/RHEL systems), because for example su/sudo/runuser should not include them.

(cherry picked from commit 0ef48896d9f23b9fd547a532a4e6e6b8f8b12901)

Resolves: #1861836