### PR TITLE
(#2161683) journalctl: do not treat EINTR as an error when waiting for events

### DIFF
--- a/src/journal/journalctl.c
+++ b/src/journal/journalctl.c
@@ -2084,8 +2084,13 @@ static int wait_for_change(sd_journal *j, int poll_fd) {
         if (r < 0)
                 return log_error_errno(r, "Failed to determine journal waiting time: %m");
 
-        if (ppoll(pollfds, ELEMENTSOF(pollfds), timeout == USEC_INFINITY ? NULL : timespec_store(&ts, timeout), NULL) < 0)
+        if (ppoll(pollfds, ELEMENTSOF(pollfds),
+                  timeout == USEC_INFINITY ? NULL : timespec_store(&ts, timeout), NULL) < 0) {
+                if (errno == EINTR)
+                        return 0;
+
                 return log_error_errno(errno, "Couldn't wait for journal event: %m");
+        }
 
         if (pollfds[1].revents & (POLLHUP|POLLERR)) { /* STDOUT has been closed? */
                 log_debug("Standard output has been closed.");


### PR DESCRIPTION
Fixup for 2a1e0f2228bbdfbc18635e959f47df7da50b62fe. Fixes #10724.

Reproducer: start 'journalctl -f' in a terminal window, change window size.

(cherry picked from commit 8e143a123276a9636987b08f555603927ca9e186)

Resolves: [#2161683](https://bugzilla.redhat.com/show_bug.cgi?id=2161683)