### PR TITLE
(#2119405) manager: limit access to private dbus socket

### DIFF
--- a/src/core/dbus.c
+++ b/src/core/dbus.c
@@ -42,6 +42,7 @@
 #include "string-util.h"
 #include "strv.h"
 #include "strxcpyx.h"
+#include "umask-util.h"
 #include "user-util.h"
 
 #define CONNECTIONS_MAX 4096
@@ -1019,7 +1020,8 @@ int bus_init_private(Manager *m) {
         if (fd < 0)
                 return log_error_errno(errno, "Failed to allocate private socket: %m");
 
-        r = bind(fd, &sa.sa, salen);
+        RUN_WITH_UMASK(0077)
+                r = bind(fd, &sa.sa, salen);
         if (r < 0)
                 return log_error_errno(errno, "Failed to bind private socket: %m");
 


### PR DESCRIPTION
For the system manager, /run/systemd/private is publicly accessible, because /run/systemd is 0755, and /run/systemd/private is 0777. For the user manager, /run/user/<uid> is 0700, and /run/user/<uid>/systemd/private is 0777. This does not directly cause any security issue because we check the sender in bus_check_peercred (ucred.uid != 0 && ucred.uid != geteuid()).

But it makes sense to limit access to the socket to avoid wasting time in PID1. Somebody could send messages there that'd we'd reject anyway. It also makes things more explicit.

(cherry picked from commit df1cbd1adf26071aab41d96e054452a3d66103a4)

Resolves: [#2119405](https://bugzilla.redhat.com/show_bug.cgi?id=2119405)