### PR TITLE
(#2059633) core: bring manager_startup() and manager_reload() more inline

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -1660,11 +1660,11 @@ int manager_startup(Manager *m, FILE *serialization, FDSet *fds) {
         /* Release any dynamic users no longer referenced */
         dynamic_user_vacuum(m, true);
 
-        exec_runtime_vacuum(m);
-
         /* Release any references to UIDs/GIDs no longer referenced, and destroy any IPC owned by them */
         manager_vacuum_uid_refs(m);
         manager_vacuum_gid_refs(m);
+
+        exec_runtime_vacuum(m);
 
         if (serialization) {
                 assert(m->n_reloading > 0);
@@ -1675,6 +1675,13 @@ int manager_startup(Manager *m, FILE *serialization, FDSet *fds) {
                  * finished */
                 m->send_reloading_done = true;
         }
+
+        /* It might be safe to log to the journal now and connect to dbus */
+        manager_recheck_journal(m);
+        manager_recheck_dbus(m);
+
+        /* Sync current state of bus names with our set of listening units */
+        (void) manager_enqueue_sync_bus_names(m);
 
         /* Let's finally catch up with any changes that took place while we were reloading/reexecing */
         manager_catchup(m);
@@ -3500,7 +3507,8 @@ int manager_reload(Manager *m) {
         lookup_paths_reduce(&m->lookup_paths);
         manager_build_unit_path_cache(m);
 
-        /* First, enumerate what we can from all config files */
+        /* First, enumerate what we can from kernel and suchlike */
+        manager_enumerate_perpetual(m);
         manager_enumerate(m);
 
         /* Second, deserialize our stored data */


### PR DESCRIPTION
Both functions do partly the same, let's make sure they do it in the same order, and that we don't miss some calls.

This makes a number of changes:

1. Moves exec_runtime_vacuum() two calls down in manager_startup(). This should not have any effect but makes manager_startup() more like manager_reload().

2. Calls manager_recheck_journal(), manager_recheck_dbus(), manager_enqueue_sync_bus_names() in manager_startup() too. This is a good idea since during reeexec we pass through manager_startup() and hence can't assume dbus and journald weren't up yet, hence let's check if they are ready to be connected to.

3. Include manager_enumerate_perpetual() in manager_reload(), too. This is not strictly necessary, since these units are included in the serialization anyway, but it's still a nice thing, in particular as theoretically the deserialization could fail.

(cherry picked from commit 3ad2afb6a204513c7834c64ab864e40169874390)

Resolves: #2059633