### PR TITLE
(#2170084) pam_systemd: suppress LOG_DEBUG log messages if debugging is off

### DIFF
--- a/src/login/pam_systemd.c
+++ b/src/login/pam_systemd.c
@@ -476,7 +476,8 @@ _public_ PAM_EXTERN int pam_sm_open_session(
         }
 
         if (seat && !streq(seat, "seat0") && vtnr != 0) {
-                pam_syslog(handle, LOG_DEBUG, "Ignoring vtnr %"PRIu32" for %s which is not seat0", vtnr, seat);
+                if (debug)
+                        pam_syslog(handle, LOG_DEBUG, "Ignoring vtnr %"PRIu32" for %s which is not seat0", vtnr, seat);
                 vtnr = 0;
         }
 
@@ -577,7 +578,8 @@ _public_ PAM_EXTERN int pam_sm_open_session(
         r = sd_bus_call(bus, m, 0, &error, &reply);
         if (r < 0) {
                 if (sd_bus_error_has_name(&error, BUS_ERROR_SESSION_BUSY)) {
-                        pam_syslog(handle, LOG_DEBUG, "Cannot create session: %s", bus_error_message(&error, r));
+                        if (debug)
+                                pam_syslog(handle, LOG_DEBUG, "Cannot create session: %s", bus_error_message(&error, r));
                         return PAM_SUCCESS;
                 } else {
                         pam_syslog(handle, LOG_ERR, "Failed to create session: %s", bus_error_message(&error, r));


### PR DESCRIPTION
In the PAM module we need to suppress LOG_DEBUG messages manually, if debug logging is not on, as PAM won't do this for us. We did this correctly for most log messages already, but two were missing. Let's fix those too.

Fixes: #10822
(cherry picked from commit 2675747f3cdd6f1e6236bbb2f79abfa53fb307f1)

Resolves: [#2170084](https://bugzilla.redhat.com/show_bug.cgi?id=2170084)