### PR TITLE
(#2170499) udev/net_id: introduce naming scheme for RHEL-8.8

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -328,6 +328,12 @@
           for that, the limit is increased to now 65535.</para></listitem>
         </varlistentry>
 
+        <varlistentry>
+          <term><constant>rhel-8.8</constant></term>
+
+          <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
+        </varlistentry>
+
         <para>Note that <constant>latest</constant> may be used to denote the latest scheme known to this
         particular version of systemd.</para>
     </variablelist>

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -141,6 +141,7 @@ typedef enum NamingSchemeFlags {
         NAMING_RHEL_8_5 = NAMING_RHEL_8_4,
         NAMING_RHEL_8_6 = NAMING_RHEL_8_4,
         NAMING_RHEL_8_7 = NAMING_RHEL_8_4|NAMING_SLOT_FUNCTION_ID|NAMING_16BIT_INDEX,
+        NAMING_RHEL_8_8 = NAMING_RHEL_8_7,
 
         _NAMING_SCHEME_FLAGS_INVALID = -1,
 } NamingSchemeFlags;
@@ -161,6 +162,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-8.5", NAMING_RHEL_8_5 },
         { "rhel-8.6", NAMING_RHEL_8_6 },
         { "rhel-8.7", NAMING_RHEL_8_7 },
+        { "rhel-8.8", NAMING_RHEL_8_8 },
         /* … add more schemes here, as the logic to name devices is updated … */
 };
 


### PR DESCRIPTION
RHEL-only

Resolves: [#2170499](https://bugzilla.redhat.com/show_bug.cgi?id=2170499)