### PR TITLE
(#2156780) logind-session: make stopping of idle session visible to admins

### DIFF
--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -673,7 +673,7 @@ static int session_dispatch_stop_on_idle(sd_event_source *source, uint64_t t, vo
 
         idle = session_get_idle_hint(s, &ts);
         if (idle) {
-                log_debug("Session \"%s\" of user \"%s\" is idle, stopping.", s->id, s->user->name);
+                log_info("Session \"%s\" of user \"%s\" is idle, stopping.", s->id, s->user->name);
 
                 return session_stop(s, /* force */ true);
         }


### PR DESCRIPTION
(cherry picked from commit 6269ffe7ee8a659df7336a2582054ecd9eecf4b1)

Resolves: [#2156780](https://bugzilla.redhat.com/show_bug.cgi?id=2156780)