### PR TITLE
(#2180380) journal-vacuum: count size of all journal files

### DIFF
--- a/src/journal/journal-vacuum.c
+++ b/src/journal/journal-vacuum.c
@@ -179,6 +179,8 @@ int journal_directory_vacuum(
                 if (!S_ISREG(st.st_mode))
                         continue;
 
+                size = 512UL * (uint64_t) st.st_blocks;
+
                 q = strlen(de->d_name);
 
                 if (endswith(de->d_name, ".journal")) {
@@ -188,6 +190,7 @@ int journal_directory_vacuum(
 
                         if (q < 1 + 32 + 1 + 16 + 1 + 16 + 8) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -195,6 +198,7 @@ int journal_directory_vacuum(
                             de->d_name[q-8-16-1-16-1] != '-' ||
                             de->d_name[q-8-16-1-16-1-32-1] != '@') {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -207,11 +211,13 @@ int journal_directory_vacuum(
                         de->d_name[q-8-16-1-16-1] = 0;
                         if (sd_id128_from_string(de->d_name + q-8-16-1-16-1-32, &seqnum_id) < 0) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
                         if (sscanf(de->d_name + q-8-16-1-16, "%16llx-%16llx.journal", &seqnum, &realtime) != 2) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -224,12 +230,14 @@ int journal_directory_vacuum(
 
                         if (q < 1 + 16 + 1 + 16 + 8 + 1) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
                         if (de->d_name[q-1-8-16-1] != '-' ||
                             de->d_name[q-1-8-16-1-16-1] != '@') {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -241,6 +249,7 @@ int journal_directory_vacuum(
 
                         if (sscanf(de->d_name + q-1-8-16-1-16, "%16llx-%16llx.journal~", &realtime, &tmp) != 2) {
                                 n_active_files++;
+                                sum += size;
                                 continue;
                         }
 
@@ -250,8 +259,6 @@ int journal_directory_vacuum(
                         log_debug("Not vacuuming unknown file %s.", de->d_name);
                         continue;
                 }
-
-                size = 512UL * (uint64_t) st.st_blocks;
 
                 r = journal_file_empty(dirfd(d), p);
                 if (r < 0) {


### PR DESCRIPTION
Currently, active journal files are excluded, which means that vacuuming may not remove anything even if *MaxUse= has been exceeded.

(cherry picked from commit 9ea46af4f2368b41d57705bac09774778126507f)

Resolves: [#2180380](https://bugzilla.redhat.com/show_bug.cgi?id=2180380)