### PR TITLE
(#2179309) Drop requirements on linting workflows

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,10 +11,6 @@ pull_request_rules:
         - -check-success=build (stream8, GCC_ASAN)
         # CentOS Stream CI
         - -check-success=CentOS CI (CentOS Stream 8)
-        # CodeQL
-        - -check-success=CodeQL
-        # Other
-        - -check-success=Differential ShellCheck
     actions:
       label:
         add:
@@ -30,10 +26,6 @@ pull_request_rules:
           - check-success=build (stream8, GCC_ASAN)
           # CentOS Stream CI
           - check-success=CentOS CI (CentOS Stream 8)
-          # CodeQL
-          - check-success=CodeQL
-          # Other
-          - check-success=Differential ShellCheck
     actions:
       label:
         remove:


### PR DESCRIPTION
CodeQL and DifferentialShellCheck workflows aren't run for all PRs on all branches. This results in Mergify incorrectly labeling PRs with `needs-ci` label. Let's drop the requirements on these workflows.