### PR TITLE
(#2186177) pstore: fix crash and forward dummy arguments instead of NULL

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -1,0 +1,23 @@
+policy:
+  cherry-pick:
+    upstream:
+      - github: systemd/systemd
+      - github: systemd/systemd-stable
+    exception:
+      note:
+        - rhel-only
+  tracker:
+    - keyword:
+        - 'Resolves: #?'
+        - 'Related: #?'
+        - 'Reverts: #?'
+      issue-format:
+        - '\d+$'
+      url: 'https://bugzilla.redhat.com/show_bug.cgi?id='
+    - keyword:
+        - 'Resolves: '
+        - 'Related: '
+        - 'Reverts: '
+      issue-format:
+        - 'RHEL-\d+$'
+      url: 'https://issues.redhat.com/browse/'

--- a/.github/workflows/gather-metadata.yml
+++ b/.github/workflows/gather-metadata.yml
@@ -1,0 +1,28 @@
+name: Gather Pull Request Metadata
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches:
+      - main
+      - rhel-8.*.0
+
+permissions:
+  contents: read
+
+jobs:
+  gather-metadata:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+
+      - id: Metadata
+        name: Gather Pull Request Metadata
+        uses: redhat-plumbers-in-action/gather-pull-request-metadata@v1
+
+      - name: Upload artifact with gathered metadata
+        uses: actions/upload-artifact@v3
+        with:
+          name: pr-metadata
+          path: ${{ steps.Metadata.outputs.metadata-file }}

--- a/.github/workflows/source-git-automation.yml
+++ b/.github/workflows/source-git-automation.yml
@@ -1,0 +1,45 @@
+name: Source git Automation
+on:
+  workflow_run:
+    workflows: [ Gather Pull Request Metadata ]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  download-metadata:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    outputs:
+      pr-metadata: ${{ steps.Artifact.outputs.pr-metadata-json }}
+
+    steps:
+      - id: Artifact
+        name: Download Artifact
+        uses: redhat-plumbers-in-action/download-artifact@v1
+        with:
+          name: pr-metadata
+
+  commit-linter:
+    needs: [ download-metadata ]
+    runs-on: ubuntu-latest
+
+    outputs:
+      validated-pr-metadata: ${{ steps.commit-linter.outputs.validated-pr-metadata }}
+
+    permissions:
+      statuses: write
+      pull-requests: write
+
+    steps:
+      - id: commit-linter
+        name: Lint Commits
+        uses: redhat-plumbers-in-action/advanced-commit-linter@v1
+        with:
+          pr-metadata: ${{ needs.download-metadata.outputs.pr-metadata }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/pstore/pstore.c
+++ b/src/pstore/pstore.c
@@ -366,7 +366,7 @@ static int run(int argc, char *argv[]) {
 
         /* Move left over files out of pstore */
         for (size_t n = 0; n < list.n_entries; n++)
-                (void) move_file(&list.entries[n], NULL, NULL);
+                (void) move_file(&list.entries[n], "/", "/");
 
         return 0;
 }


### PR DESCRIPTION
[msekleta: in our version of systemd "const char path*" argument of path_join() can't be NULL. Here we don't really want any subdirs paths passed into move_file(), but we can't just pass NULL pointers because they will be forwarded to path_join(). Hence, let's just pass "/" instead.]

RHEL-only

Related: #2186177