### PR TITLE
(#2190151) pstore: fix crash and forward dummy arguments instead of NULL

### DIFF
--- a/src/pstore/pstore.c
+++ b/src/pstore/pstore.c
@@ -366,7 +366,7 @@ static int run(int argc, char *argv[]) {
 
         /* Move left over files out of pstore */
         for (size_t n = 0; n < list.n_entries; n++)
-                (void) move_file(&list.entries[n], NULL, NULL);
+                (void) move_file(&list.entries[n], "/", "/");
 
         return 0;
 }


### PR DESCRIPTION
[msekleta: in our version of systemd "const char path*" argument of path_join() can't be NULL. Here we don't really want any subdirs paths passed into move_file(), but we can't just pass NULL pointers because they will be forwarded to path_join(). Hence, let's just pass "/" instead.]

RHEL-only

Related: #2190151