### PR TITLE
(#2179309) ci(lint): add new exception keyword for upstream references

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -5,7 +5,10 @@ policy:
       - github: systemd/systemd-stable
     exception:
       note:
+        # Exception for RHEL-only commits that should be kept in case of rebase
         - rhel-only
+        # Exception for commits that cannot be cherry-picked due to conflicts but are based on upstream commits
+        - based-on-upstream
   tracker:
     - keyword:
         - 'Resolves: #?'


### PR DESCRIPTION
for details see: https://github.com/redhat-plumbers/systemd-rhel8/pull/387#issuecomment-1534701242

rhel-only

Related: #2179309

<!-- advanced-commit-linter = {"comment-id":"1534785995"} -->