### PR TITLE
(#2179309) ci: update permissions for source-git automation workflows

### DIFF
--- a/.github/workflows/source-git-automation.yml
+++ b/.github/workflows/source-git-automation.yml
@@ -33,7 +33,7 @@ jobs:
       validated-pr-metadata: ${{ steps.commit-linter.outputs.validated-pr-metadata }}
 
     permissions:
-      statuses: write
+      checks: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
The new version of `redhat-plumbers-in-action/advanced-commit-linter` requires new permission: `checks: write`.

https://github.com/redhat-plumbers-in-action/advanced-commit-linter/commit/f1bb35fcdeff83d40eb67b5e7c58baad6be689b2

rhel-only

Related: #2179309

---
Check release notes: https://github.com/redhat-plumbers-in-action/advanced-commit-linter/releases/tag/v1.2.0