### PR TITLE
(RHEL-5991) Do not assign badness to filtered-out syscalls

### DIFF
--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -480,26 +480,24 @@ static bool syscall_names_in_filter(Set *s, bool whitelist, const SyscallFilterS
         const char *syscall;
 
         NULSTR_FOREACH(syscall, f->value) {
-                bool b;
+                int id;
 
                 if (syscall[0] == '@') {
                         const SyscallFilterSet *g;
+
                         assert_se(g = syscall_filter_set_find(syscall));
-                        b = syscall_names_in_filter(s, whitelist, g);
-                } else {
-#if HAVE_SECCOMP
-                        int id;
+                        if (syscall_names_in_filter(s, whitelist, g))
+                                return true; /* bad! */
 
-                        /* Let's see if the system call actually exists on this platform, before complaining */
-                        id = seccomp_syscall_resolve_name(syscall);
-                        if (id < 0)
-                                continue;
-#endif
-
-                        b = set_contains(s, syscall);
+                        continue;
                 }
 
-                if (whitelist == b) {
+                /* Let's see if the system call actually exists on this platform, before complaining */
+                id = seccomp_syscall_resolve_name(syscall);
+                if (id < 0)
+                        continue;
+
+                if (set_contains(s, syscall) == whitelist) {
                         log_debug("Offending syscall filter item: %s", syscall);
                         return true; /* bad! */
                 }

--- a/src/analyze/analyze-security.c
+++ b/src/analyze/analyze-security.c
@@ -549,7 +549,7 @@ static int assess_system_call_filter(
                                 b = 10;
                         } else {
                                 (void) asprintf(&d, "System call blacklist defined for service, and %s is included", f->name);
-                                b = 5;
+                                b = 0;
                         }
                 }
         }


### PR DESCRIPTION
Resolves: [#2196807](https://bugzilla.redhat.com/show_bug.cgi?id=2196807)

<!-- issue-commentator = {"comment-id":"1612576007"} -->