### PR TITLE
(#2179309) Allow RHEL-only labels to mark downstream-only commits

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -6,6 +6,7 @@ policy:
     exception:
       note:
         - rhel-only
+        - RHEL-only
   tracker:
     - keyword:
         - 'Resolves: #?'


### PR DESCRIPTION
Note: Updated configuration needs to be available on the `main` branch for this to work. It's the standard behavior of `on: workflow_run` trigger.

<!-- advanced-commit-linter = {"comment-id":"1628694792"} -->