### PR TITLE
(#2231846) udev/net_id: introduce naming scheme for RHEL-8.9

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -334,6 +334,12 @@
           <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
         </varlistentry>
 
+        <varlistentry>
+          <term><constant>rhel-8.9</constant></term>
+
+          <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
+        </varlistentry>
+
         <para>Note that <constant>latest</constant> may be used to denote the latest scheme known to this
         particular version of systemd.</para>
     </variablelist>

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -142,6 +142,7 @@ typedef enum NamingSchemeFlags {
         NAMING_RHEL_8_6 = NAMING_RHEL_8_4,
         NAMING_RHEL_8_7 = NAMING_RHEL_8_4|NAMING_SLOT_FUNCTION_ID|NAMING_16BIT_INDEX,
         NAMING_RHEL_8_8 = NAMING_RHEL_8_7,
+        NAMING_RHEL_8_9 = NAMING_RHEL_8_7,
 
         _NAMING_SCHEME_FLAGS_INVALID = -1,
 } NamingSchemeFlags;
@@ -163,6 +164,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-8.6", NAMING_RHEL_8_6 },
         { "rhel-8.7", NAMING_RHEL_8_7 },
         { "rhel-8.8", NAMING_RHEL_8_8 },
+        { "rhel-8.9", NAMING_RHEL_8_9 },
         /* … add more schemes here, as the logic to name devices is updated … */
 };
 


### PR DESCRIPTION
rhel-only

Resolves: #2231846

<!-- advanced-commit-linter = {"comment-id":"1677374772"} -->