### PR TITLE
(RHEL-1087) ci: add missing configuration for commit linter

### DIFF
--- a/.github/advanced-commit-linter.yml
+++ b/.github/advanced-commit-linter.yml
@@ -11,6 +11,7 @@ policy:
         - 'Resolves: #?'
         - 'Related: #?'
         - 'Reverts: #?'
+      type: bugzilla
       issue-format:
         - '\d+$'
       url: 'https://bugzilla.redhat.com/show_bug.cgi?id='
@@ -18,6 +19,7 @@ policy:
         - 'Resolves: '
         - 'Related: '
         - 'Reverts: '
+      type: jira
       issue-format:
         - 'RHEL-\d+$'
       url: 'https://issues.redhat.com/browse/'


### PR DESCRIPTION
rhel-only

Related: RHEL-1087