### PR TITLE
(RHEL-1087) ci: add `Red Hat Enterprise Linux 8` to the list of supported products

### DIFF
--- a/.github/tracker-validator.yml
+++ b/.github/tracker-validator.yml
@@ -4,6 +4,7 @@ labels:
   invalid-component: tracker/invalid-component
   unapproved: tracker/unapproved
 products:
+  - Red Hat Enterprise Linux 8
   - CentOS Stream 8
   - rhel-8.2.0
   - rhel-8.4.0


### PR DESCRIPTION
rhel-only

Related: RHEL-1087

<!-- advanced-commit-linter = {"comment-id":"1725506131"} -->