### PR TITLE
(RHEL-18768) time-util: fix buffer-over-run

### DIFF
--- a/src/basic/time-util.c
+++ b/src/basic/time-util.c
@@ -515,7 +515,7 @@ char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
                         t = b;
                 }
 
-                n = MIN((size_t) k, l);
+                n = MIN((size_t) k, l-1);
 
                 l -= n;
                 p += n;

--- a/src/test/test-time-util.c
+++ b/src/test/test-time-util.c
@@ -446,6 +446,12 @@ int main(int argc, char *argv[]) {
         test_format_timespan(1);
         test_format_timespan(USEC_PER_MSEC);
         test_format_timespan(USEC_PER_SEC);
+
+        /* See issue #23928. */
+        _cleanup_free_ char *buf;
+        assert_se(buf = new(char, 5));
+        assert_se(buf == format_timespan(buf, 5, 100005, 1000));
+
         test_timezone_is_valid();
         test_get_timezones();
         test_usec_add();


### PR DESCRIPTION
Fixes #23928.

(cherry picked from commit 9102c625a673a3246d7e73d8737f3494446bad4e)

Note there is an existing backport commit (https://github.com/redhat-plumbers/systemd-rhel8/commit/a521f942d5c304bca7c61bacb3c79e565853718e) in the `rhel-8.8.0` branch but that has placed the [following section](https://github.com/redhat-plumbers/systemd-rhel8/blame/main/src/test/test-time-util.c#L191) in `test_format_timespan()` in `src/test/test-time-util.c`, thus calling the test asserts on each `test_format_timespan()` call, while I believe it is more appropriate in the `main()`:

```c
        /* See issue #23928. */
        _cleanup_free_ char *buf;
        assert_se(buf = new(char, 5));
        assert_se(buf == format_timespan(buf, 5, 100005, 1000));
```
Please advise.

Resolves: RHEL-18768

<!-- issue-commentator = {"comment-id":"1892580331"} -->