### PR TITLE
(RHEL-22426) udev/net_id: introduce naming scheme for RHEL-8.10

### DIFF
--- a/man/systemd.net-naming-scheme.xml
+++ b/man/systemd.net-naming-scheme.xml
@@ -340,6 +340,12 @@
           <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
         </varlistentry>
 
+        <varlistentry>
+          <term><constant>rhel-8.10</constant></term>
+
+          <para>Same as naming scheme <constant>rhel-8.7</constant>.</para>
+        </varlistentry>
+
         <para>Note that <constant>latest</constant> may be used to denote the latest scheme known to this
         particular version of systemd.</para>
     </variablelist>

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -143,6 +143,7 @@ typedef enum NamingSchemeFlags {
         NAMING_RHEL_8_7 = NAMING_RHEL_8_4|NAMING_SLOT_FUNCTION_ID|NAMING_16BIT_INDEX,
         NAMING_RHEL_8_8 = NAMING_RHEL_8_7,
         NAMING_RHEL_8_9 = NAMING_RHEL_8_7,
+        NAMING_RHEL_8_10 = NAMING_RHEL_8_7,
 
         _NAMING_SCHEME_FLAGS_INVALID = -1,
 } NamingSchemeFlags;
@@ -165,6 +166,7 @@ static const NamingScheme naming_schemes[] = {
         { "rhel-8.7", NAMING_RHEL_8_7 },
         { "rhel-8.8", NAMING_RHEL_8_8 },
         { "rhel-8.9", NAMING_RHEL_8_9 },
+        { "rhel-8.10", NAMING_RHEL_8_10 },
         /* … add more schemes here, as the logic to name devices is updated … */
 };
 


### PR DESCRIPTION
rhel-only

Resolves: RHEL-22426

<!-- issue-commentator = {"comment-id":"1906150906"} -->