### PR TITLE
(RHEL-1087) ci: add configuration for regression sniffer GA

### DIFF
--- a/.github/regression-sniffer.yml
+++ b/.github/regression-sniffer.yml
@@ -1,0 +1,1 @@
+upstream: systemd/systemd


### PR DESCRIPTION
rhel-only

Related: RHEL-1087

<!-- issue-commentator = {"comment-id":"1976499531"} -->