### PR TITLE
(RHEL-28048) pam: add call to pam_umask

### DIFF
--- a/man/systemd.exec.xml
+++ b/man/systemd.exec.xml
@@ -590,8 +590,13 @@ CapabilityBoundingSet=~CAP_B CAP_C</programlisting>
         <term><varname>UMask=</varname></term>
 
         <listitem><para>Controls the file mode creation mask. Takes an access mode in octal notation. See
-        <citerefentry><refentrytitle>umask</refentrytitle><manvolnum>2</manvolnum></citerefentry> for details. Defaults
-        to 0022.</para></listitem>
+        <citerefentry><refentrytitle>umask</refentrytitle><manvolnum>2</manvolnum></citerefentry> for
+        details. Defaults to 0022 for system units. For units of the user service manager the default value
+        is inherited from the user instance (whose default is inherited from the system service manager, and
+        thus also is 0022). Hence changing the default value of a user instance, either via
+        <varname>UMask=</varname> or via a PAM module, will affect the user instance itself and all user
+        units started by the user instance unless a user unit has specified its own
+        <varname>UMask=</varname>.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -657,6 +657,23 @@ int get_process_ppid(pid_t pid, pid_t *ret) {
         return 0;
 }
 
+int get_process_umask(pid_t pid, mode_t *umask) {
+        _cleanup_free_ char *m = NULL;
+        const char *p;
+        int r;
+
+        assert(umask);
+        assert(pid >= 0);
+
+        p = procfs_file_alloca(pid, "status");
+
+        r = get_proc_field(p, "Umask", WHITESPACE, &m);
+        if (r == -ENOENT)
+                return -ESRCH;
+
+        return parse_mode(m, umask);
+}
+
 int wait_for_terminate(pid_t pid, siginfo_t *status) {
         siginfo_t dummy;
 

--- a/src/basic/process-util.h
+++ b/src/basic/process-util.h
@@ -41,6 +41,7 @@ int get_process_cwd(pid_t pid, char **cwd);
 int get_process_root(pid_t pid, char **root);
 int get_process_environ(pid_t pid, char **environ);
 int get_process_ppid(pid_t pid, pid_t *ppid);
+int get_process_umask(pid_t pid, mode_t *umask);
 
 int wait_for_terminate(pid_t pid, siginfo_t *status);
 

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -167,8 +167,16 @@ static void unit_init(Unit *u) {
         if (ec) {
                 exec_context_init(ec);
 
-                ec->keyring_mode = MANAGER_IS_SYSTEM(u->manager) ?
-                        EXEC_KEYRING_SHARED : EXEC_KEYRING_INHERIT;
+                if (MANAGER_IS_SYSTEM(u->manager))
+                        ec->keyring_mode = EXEC_KEYRING_SHARED;
+                else {
+                        ec->keyring_mode = EXEC_KEYRING_INHERIT;
+
+                        /* User manager might have its umask redefined by PAM or UMask=. In this
+                         * case let the units it manages inherit this value by default. They can
+                         * still tune this value through their own unit file */
+                        (void) get_process_umask(getpid_cached(), &ec->umask);
+                }
         }
 
         kc = unit_get_kill_context(u);

--- a/src/login/systemd-user.m4
+++ b/src/login/systemd-user.m4
@@ -10,4 +10,5 @@ session required pam_selinux.so nottys open
 session required pam_loginuid.so
 session optional pam_keyinit.so force revoke
 session required pam_namespace.so
+session optional pam_umask.so silent
 session optional pam_systemd.so


### PR DESCRIPTION
Setting umask for user sessions via UMASK setting in /etc/login.defs is
a well-known feature. Let's make sure that user manager also runs with
this umask value.

Follow-up for https://github.com/redhat-plumbers/systemd-rhel8/commit/5e37d1930b41b24c077ce37c6db0e36c745106c7.

(cherry picked from commit 159f1b78576ce91c3932f4867f07361a530875d3)

Resolves: RHEL-28048

<!-- issue-commentator = {"comment-id":"1991013210"} -->