### PR TITLE
(RHEL-32494) ci: update `actions/upload-artifact` to `v4`

### DIFF
--- a/.github/workflows/deploy-man-pages.yml
+++ b/.github/workflows/deploy-man-pages.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          RELEASE="$(lsb_release -cs)"
           sudo add-apt-repository -y --no-update --enable-source
           sudo apt-get -y update
           sudo apt-get -y build-dep systemd

--- a/.github/workflows/gather-metadata.yml
+++ b/.github/workflows/gather-metadata.yml
@@ -22,7 +22,7 @@ jobs:
         uses: redhat-plumbers-in-action/gather-pull-request-metadata@v1
 
       - name: Upload artifact with gathered metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-metadata
           path: ${{ steps.Metadata.outputs.metadata-file }}


### PR DESCRIPTION
`v3` will be deprecated soon, so update to `v4`.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

rhel-only

Related: RHEL-32494

<!-- issue-commentator = {"comment-id":"2077135978"} -->