### PR TITLE
(RHEL-19215) logind: don't setup idle session watch for lock-screen and greeter

### DIFF
--- a/man/logind.conf.xml
+++ b/man/logind.conf.xml
@@ -343,10 +343,11 @@
         <term><varname>StopIdleSessionSec=</varname></term>
 
         <listitem><para>Specifies a timeout in seconds, or a time span value after which
-        <filename>systemd-logind</filename> checks the idle state of all sessions. Every session that is idle for
-        longer then the timeout will be stopped. Defaults to <literal>infinity</literal>
-        (<filename>systemd-logind</filename> is not checking the idle state of sessions). For details about the syntax
-        of time spans, see
+        <filename>systemd-logind</filename> checks the idle state of all sessions. Every session that is idle
+        for longer than the timeout will be stopped. Note that this option doesn't apply to
+        <literal>greeter</literal> or <literal>lock-screen</literal> sessions. Defaults to
+        <literal>infinity</literal> (<filename>systemd-logind</filename> is not checking the idle state
+        of sessions). For details about the syntax of time spans, see
         <citerefentry><refentrytitle>systemd.time</refentrytitle><manvolnum>7</manvolnum></citerefentry>.
         </para></listitem>
       </varlistentry>

--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -713,7 +713,7 @@ static int session_setup_stop_on_idle_timer(Session *s) {
 
         assert(s);
 
-        if (s->manager->stop_idle_session_usec == USEC_INFINITY)
+        if (s->manager->stop_idle_session_usec == USEC_INFINITY || IN_SET(s->class, SESSION_GREETER, SESSION_LOCK_SCREEN))
                 return 0;
 
         r = sd_event_add_time_relative(

--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -713,7 +713,7 @@ static int session_setup_stop_on_idle_timer(Session *s) {
 
         assert(s);
 
-        if (s->manager->stop_idle_session_usec == USEC_INFINITY || IN_SET(s->class, SESSION_GREETER, SESSION_LOCK_SCREEN))
+        if (s->manager->stop_idle_session_usec == USEC_INFINITY || !SESSION_CLASS_CAN_STOP_ON_IDLE(s->class))
                 return 0;
 
         r = sd_event_add_time_relative(

--- a/src/login/logind-session.h
+++ b/src/login/logind-session.h
@@ -26,6 +26,9 @@ typedef enum SessionClass {
         _SESSION_CLASS_INVALID = -1
 } SessionClass;
 
+/* Which sessions classes should be subject to stop-in-idle */
+#define SESSION_CLASS_CAN_STOP_ON_IDLE(class) (IN_SET((class), SESSION_USER))
+
 typedef enum SessionType {
         SESSION_UNSPECIFIED,
         SESSION_TTY,


### PR DESCRIPTION
Reason to skip the idle session logic for these session classes is that
they are idle by default.

(cherry picked from commit 508b4786e8592e82eb4832549f74aaa54335d14c)

Resolves: RHEL-19215


<!-- issue-commentator = {"comment-id":"2457293814"} -->