### PR TITLE
(RHEL-76308) core: fix member access within null pointer

### DIFF
--- a/src/core/load-fragment.c
+++ b/src/core/load-fragment.c
@@ -3123,7 +3123,7 @@ int config_parse_tasks_max(
         int r;
 
         if (isempty(rvalue)) {
-                *tasks_max = u->manager->default_tasks_max;
+                *tasks_max = u ? u->manager->default_tasks_max : UINT64_MAX;
                 return 0;
         }
 


### PR DESCRIPTION
config_parse_tasks_max() is also used for parsing system.conf or user.conf. In that case, userdata is NULL.

Fixes #10362.

(cherry picked from commit 958b8c7bd7a3cf1e710faf8c19a528cc94c214fe)

Resolves: RHEL-76308

<!-- issue-commentator = {"comment-id":"2618242987"} -->