### PR TITLE
(RHEL-77145) man: be even clearer that tmpfiles user/group/mode are applied on exi…

### DIFF
--- a/man/tmpfiles.d.xml
+++ b/man/tmpfiles.d.xml
@@ -500,6 +500,11 @@ r! /tmp/.X[0-9]*-lock</programlisting>
       sticky/SUID/SGID bit is removed unless applied to a
       directory. This functionality is particularly useful in
       conjunction with <varname>Z</varname>.</para>
+
+      <para>By default the access mode of listed inodes is set to the specified mode regardless if it is
+      created anew, or already existed. Optionally, if prefixed with <literal>:</literal>, the configured
+      access mode is only applied when creating new inodes, and if the inode the line refers to
+      already exists, its access mode is left in place unmodified.</para>
     </refsect2>
 
     <refsect2>
@@ -515,6 +520,11 @@ r! /tmp/.X[0-9]*-lock</programlisting>
       <varname>r</varname>, <varname>R</varname>,
       <varname>L</varname>, <varname>t</varname>, and
       <varname>a</varname> lines.</para>
+
+      <para>By default the ownership of listed inodes is set to the specified user/group regardless if it is
+      created anew, or already existed. Optionally, if prefixed with <literal>:</literal>, the configured
+      user/group information is only applied when creating new inodes, and if the inode the line refers to
+      already exists, its user/group is left in place unmodified.</para>
     </refsect2>
 
     <refsect2>


### PR DESCRIPTION
…sting inodes

I think it was clear already, but let's be even clearer.

Fixes: #29774
(cherry picked from commit 3cb938bd12b3603984b982e9b73e4cabd4a608e3)

Resolves: RHEL-77145

<!-- issue-commentator = {"comment-id":"2626761983"} -->