### PR TITLE
(RHEL-81056) man: explicitly document that "reboot -f" is different from "systemctl reboot -f"

### DIFF
--- a/man/halt.xml
+++ b/man/halt.xml
@@ -88,13 +88,8 @@
         <term><option>-f</option></term>
         <term><option>--force</option></term>
 
-        <listitem><para>Force immediate halt, power-off, or reboot. When
-        specified once, this results in an immediate but clean shutdown
-        by the system manager. When specified twice, this results in an
-        immediate shutdown without contacting the system manager. See the
-        description of <option>--force</option> in
-        <citerefentry><refentrytitle>systemctl</refentrytitle><manvolnum>1</manvolnum></citerefentry>
-        for more details.</para></listitem>
+        <listitem><para>Force immediate halt, power-off, reboot. Do
+        not contact the init system.</para></listitem>
       </varlistentry>
 
       <varlistentry>

--- a/man/halt.xml
+++ b/man/halt.xml
@@ -88,8 +88,12 @@
         <term><option>-f</option></term>
         <term><option>--force</option></term>
 
-        <listitem><para>Force immediate halt, power-off, reboot. Do
-        not contact the init system.</para></listitem>
+        <listitem>
+          <para>Force immediate halt, power-off, reboot. If specified, the command does not contact the init
+          system. In most cases, filesystems are not properly unmounted before shutdown. For example, the
+          command <command>reboot -f</command> is mostly equivalent to <command>systemctl reboot -ff</command>,
+          instead of <command>systemctl reboot -f</command>.</para>
+        </listitem>
       </varlistentry>
 
       <varlistentry>


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"2700762231"} -->