### PR TITLE
test-execute: let's ignore the difference between CLD_KILLED and CLD_DUMPED

### DIFF
--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -30,6 +30,12 @@
 
 typedef void (*test_function_t)(Manager *m);
 
+static int cld_dumped_to_killed(int code) {
+        /* Depending on the system, seccomp version, … some signals might result in dumping, others in plain
+         * killing. Let's ignore the difference here, and map both cases to CLD_KILLED */
+        return code == CLD_DUMPED ? CLD_KILLED : code;
+}
+
 static void wait_for_service_finish(Manager *m, Unit *unit) {
         Service *service = NULL;
         usec_t ts;
@@ -73,7 +79,7 @@ static void check_main_result(const char *func, Manager *m, Unit *unit, int stat
                           service->main_exec_status.status, status_expected);
                 abort();
         }
-        if (service->main_exec_status.code != code_expected) {
+        if (cld_dumped_to_killed(service->main_exec_status.code) != cld_dumped_to_killed(code_expected)) {
                 log_error("%s: %s: exit code %d, expected %d",
                           func, unit->id,
                           service->main_exec_status.code, code_expected);

--- a/test/test-execute/exec-systemcallfilter-failing.service
+++ b/test/test-execute/exec-systemcallfilter-failing.service
@@ -4,6 +4,7 @@ Description=Test for SystemCallFilter
 [Service]
 ExecStart=/bin/sh -c 'echo "This should not be seen"'
 Type=oneshot
+LimitCORE=0
 SystemCallFilter=ioperm
 SystemCallFilter=~ioperm
 SystemCallFilter=ioperm

--- a/test/test-execute/exec-systemcallfilter-failing2.service
+++ b/test/test-execute/exec-systemcallfilter-failing2.service
@@ -4,4 +4,5 @@ Description=Test for SystemCallFilter
 [Service]
 ExecStart=/bin/sh -c 'echo "This should not be seen"'
 Type=oneshot
+LimitCORE=0
 SystemCallFilter=~write open execve exit_group close mmap munmap fstat DONOTEXIST


### PR DESCRIPTION
Depending on system configuration and whether SCMP_ACT_KILL_PROCESS or SCMP_ACT_KILL_THREAD is available/used processes might coredump on specific coredumps or are just plain killed. For our test case the difference doesn't really matter, hence let's hide it away.

(cherry picked from commit c3ab2c389ee60d92fb8d7fe779ae9c4e3c092e4c)

<!-- issue-commentator = {"comment-id":"3245087007"} -->