### PR TITLE
(RHEL-108744) timer: don't run service immediately after restart of a timer

### DIFF
--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -601,8 +601,6 @@ static int timer_start(Unit *u) {
         if (r < 0)
                 return r;
 
-        t->last_trigger = DUAL_TIMESTAMP_NULL;
-
         /* Reenable all timers that depend on unit activation time */
         LIST_FOREACH(value, v, t->values)
                 if (v->base == TIMER_ACTIVE)

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -30,6 +30,12 @@
 
 typedef void (*test_function_t)(Manager *m);
 
+static int cld_dumped_to_killed(int code) {
+        /* Depending on the system, seccomp version, … some signals might result in dumping, others in plain
+         * killing. Let's ignore the difference here, and map both cases to CLD_KILLED */
+        return code == CLD_DUMPED ? CLD_KILLED : code;
+}
+
 static void wait_for_service_finish(Manager *m, Unit *unit) {
         Service *service = NULL;
         usec_t ts;
@@ -73,7 +79,7 @@ static void check_main_result(const char *func, Manager *m, Unit *unit, int stat
                           service->main_exec_status.status, status_expected);
                 abort();
         }
-        if (service->main_exec_status.code != code_expected) {
+        if (cld_dumped_to_killed(service->main_exec_status.code) != cld_dumped_to_killed(code_expected)) {
                 log_error("%s: %s: exit code %d, expected %d",
                           func, unit->id,
                           service->main_exec_status.code, code_expected);

--- a/test/TEST-53-TIMER/Makefile
+++ b/test/TEST-53-TIMER/Makefile
@@ -1,0 +1,1 @@
+../TEST-01-BASIC/Makefile

--- a/test/TEST-53-TIMER/test.sh
+++ b/test/TEST-53-TIMER/test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+TEST_DESCRIPTION="Tests for systemd timers"
+TEST_NO_NSPAWN=1
+
+# shellcheck source=test/test-functions
+. "$TEST_BASE_DIR/test-functions"
+
+test_setup() {
+    create_empty_image
+    mkdir -p "${TESTDIR:?}/root"
+    mount "${LOOPDEV:?}p1" "$TESTDIR/root"
+
+    (
+        LOG_LEVEL=5
+        # shellcheck disable=SC2046
+        eval $(udevadm info --export --query=env --name="${LOOPDEV}p2")
+
+        setup_basic_environment
+
+        # mask some services that we do not want to run in these tests
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-hwdb-update.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-journal-catalog-update.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-networkd.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-networkd.socket"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-resolved.service"
+        ln -fs /dev/null "$initdir/etc/systemd/system/systemd-machined.service"
+
+        # setup the testsuite service
+        cat >"$initdir/etc/systemd/system/testsuite.service" <<EOF
+[Unit]
+Description=Testsuite service
+
+[Service]
+ExecStart=/bin/bash -x /testsuite.sh
+Type=oneshot
+StandardOutput=tty
+StandardError=tty
+NotifyAccess=all
+EOF
+        cp testsuite*.sh "$initdir/"
+
+        setup_testsuite
+    ) || return 1
+    setup_nspawn_root
+
+    ddebug "umount $TESTDIR/root"
+    umount "$TESTDIR/root"
+}
+
+do_test "$@"

--- a/test/TEST-53-TIMER/testsuite.RandomizedDelaySec-reload.sh
+++ b/test/TEST-53-TIMER/testsuite.RandomizedDelaySec-reload.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# When deserializing a serialized timer unit with RandomizedDelaySec= set, systemd should use the last
+# inactive exit timestamp instead of current realtime to calculate the new next elapse, so the timer unit
+# actually runs in the given calendar window.
+#
+# Provides coverage for:
+#   - https://github.com/systemd/systemd/issues/18678
+#   - https://github.com/systemd/systemd/pull/27752
+set -eux
+set -o pipefail
+
+UNIT_NAME="timer-RandomizedDelaySec-$RANDOM"
+TARGET_TS="$(date --date="tomorrow 00:10")"
+TARGET_TS_S="$(date --date="$TARGET_TS" "+%s")"
+# Maximum possible next elapse timestamp: $TARGET_TS (OnCalendar=) + 22 hours (RandomizedDelaySec=)
+MAX_NEXT_ELAPSE_REALTIME_S="$((TARGET_TS_S + 22 * 60 * 60))"
+MAX_NEXT_ELAPSE_REALTIME="$(date --date="@$MAX_NEXT_ELAPSE_REALTIME_S")"
+
+# Let's make sure to return the date & time back to the original state once we're done with our time
+# shenigans. One way to do this would be to use hwclock, but the RTC in VMs can be unreliable or slow to
+# respond, causing unexpected test fails/timeouts.
+#
+# Instead, let's save the realtime timestamp before we start with the test together with a current monotonic
+# timestamp, after the test ends take the difference between the current monotonic timestamp and the "start"
+# one, add it to the originally saved realtime timestamp, and finally use that timestamp to set the system
+# time. This should advance the system time by the amount of time the test actually ran, and hence restore it
+# to some sane state after the time jumps performed by the test. It won't be perfect, but it should be close
+# enough for our needs.
+START_REALTIME="$(date "+%s")"
+START_MONOTONIC="$(cut -d . -f 1 /proc/uptime)"
+at_exit() {
+    : "Restore the system date to a sane state"
+    END_MONOTONIC="$(cut -d . -f 1 /proc/uptime)"
+    date --set="@$((START_REALTIME + END_MONOTONIC - START_MONOTONIC))"
+}
+trap at_exit EXIT
+
+# Set some predictable time so we can schedule the first timer elapse in a deterministic-ish way
+date --set="23:00"
+
+# Setup
+cat >"/run/systemd/system/$UNIT_NAME.timer" <<EOF
+[Timer]
+# Run this timer daily, ten minutes after midnight
+OnCalendar=*-*-* 00:10:00
+RandomizedDelaySec=22h
+AccuracySec=1ms
+EOF
+
+cat >"/run/systemd/system/$UNIT_NAME.service" <<EOF
+[Service]
+ExecStart=echo "Hello world"
+EOF
+
+systemctl daemon-reload
+
+check_elapse_timestamp() {
+    systemctl status --no-pager "$UNIT_NAME.timer"
+    systemctl show -p InactiveExitTimestamp --no-pager "$UNIT_NAME.timer"
+
+    NEXT_ELAPSE_REALTIME="$(systemctl show -p NextElapseUSecRealtime "$UNIT_NAME.timer" | cut -d = -f 2)"
+    NEXT_ELAPSE_REALTIME_S="$(date --date="$NEXT_ELAPSE_REALTIME" "+%s")"
+    : "Next elapse timestamp should be $TARGET_TS <= $NEXT_ELAPSE_REALTIME <= $MAX_NEXT_ELAPSE_REALTIME"
+    [[ "$NEXT_ELAPSE_REALTIME_S" -ge "$TARGET_TS_S" ]]
+    [[ "$NEXT_ELAPSE_REALTIME_S" -le "$MAX_NEXT_ELAPSE_REALTIME_S" ]]
+}
+
+# Restart the timer unit and check the initial next elapse timestamp
+: "Initial next elapse timestamp"
+systemctl restart "$UNIT_NAME.timer"
+check_elapse_timestamp
+
+# Bump the system date to 1 minute after the original calendar timer would've expired (without any random
+# delay!) - systemd should recalculate the next elapse timestamp with a new randomized delay, but it should
+# use the original inactive exit timestamp as a "base", so the final timestamp should not end up beyond the
+# original calendar timestamp + randomized delay range.
+#
+# Similarly, do the same check after doing daemon-reload, as that also forces systemd to recalculate the next
+# elapse timestamp (this goes through a slightly different codepath that actually contained the original
+# issue).
+: "Next elapse timestamp after time jump"
+date -s "tomorrow 00:11"
+check_elapse_timestamp
+
+: "Next elapse timestamp after daemon-reload"
+systemctl daemon-reload
+check_elapse_timestamp
+
+# Cleanup
+systemctl stop "$UNIT_NAME".{timer,service}
+rm -f "/run/systemd/system/$UNIT_NAME".{timer,service}
+systemctl daemon-reload

--- a/test/TEST-53-TIMER/testsuite.restart-trigger.sh
+++ b/test/TEST-53-TIMER/testsuite.restart-trigger.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Restarting an already elapsed timer shouldn't immediately trigger the corresponding service unit.
+#
+# Provides coverage for:
+#   - https://github.com/systemd/systemd/issues/31231
+#   - https://github.com/systemd/systemd/issues/35805
+set -eux
+set -o pipefail
+
+UNIT_NAME="timer-restart-$RANDOM"
+TEST_MESSAGE="Hello from timer $RANDOM"
+
+# Setup
+cat >"/run/systemd/system/$UNIT_NAME.timer" <<EOF
+[Timer]
+OnCalendar=$(date --date="+1 hour" "+%Y-%m-%d %H:%M:%S")
+AccuracySec=1s
+EOF
+
+cat >"/run/systemd/system/$UNIT_NAME.service" <<EOF
+[Service]
+ExecStart=echo "$TEST_MESSAGE"
+EOF
+
+systemctl daemon-reload
+
+JOURNAL_TS="$(date "+%s")"
+# Paranoia check that the test message is not already in the logs
+[[ "$(journalctl -q -p info --since="@$JOURNAL_TS" --unit="$UNIT_NAME" --grep="$TEST_MESSAGE" | wc -l)" -eq 0 ]]
+
+# Restart time timer and move time forward by 2 hours to trigger the timer
+systemctl restart "$UNIT_NAME.timer"
+systemctl status --no-pager "$UNIT_NAME.timer"
+
+date -s '+2 hours'
+trap 'date -s "-2 hours"' EXIT
+sleep 1
+systemctl status --no-pager "$UNIT_NAME.timer"
+[[ "$(journalctl -q -p info --since="@$JOURNAL_TS" --unit="$UNIT_NAME" --grep="$TEST_MESSAGE" | wc -l)" -eq 1 ]]
+
+# Restarting the timer unit shouldn't trigger neither the timer nor the service, so these
+# fields should remain constant through the following tests
+SERVICE_INV_ID="$(systemctl show --property=InvocationID "$UNIT_NAME.service")"
+TIMER_LAST_TRIGGER="$(systemctl show --property=LastTriggerUSec "$UNIT_NAME.timer")"
+
+# Now restart the timer and check if the timer and the service weren't triggered again
+systemctl restart "$UNIT_NAME.timer"
+sleep 5
+[[ "$(journalctl -q -p info --since="@$JOURNAL_TS" --unit="$UNIT_NAME" --grep="$TEST_MESSAGE" | wc -l)" -eq 1 ]]
+[[ "$SERVICE_INV_ID" == "$(systemctl show --property=InvocationID "$UNIT_NAME.service")" ]]
+[[ "$TIMER_LAST_TRIGGER" == "$(systemctl show --property=LastTriggerUSec "$UNIT_NAME.timer")" ]]
+
+# Set the timer into the past, restart it, and again check if it wasn't triggered
+TIMER_TS="$(date --date="-1 day" "+%Y-%m-%d %H:%M:%S")"
+mkdir "/run/systemd/system/$UNIT_NAME.timer.d/"
+cat >"/run/systemd/system/$UNIT_NAME.timer.d/99-override.conf" <<EOF
+[Timer]
+OnCalendar=$TIMER_TS
+EOF
+systemctl daemon-reload
+systemctl status --no-pager "$UNIT_NAME.timer"
+[[ "$(systemctl show -p TimersCalendar "$UNIT_NAME".timer)" == *"OnCalendar=$TIMER_TS"* ]]
+systemctl restart "$UNIT_NAME.timer"
+sleep 5
+[[ "$(journalctl -q -p info --since="@$JOURNAL_TS" --unit="$UNIT_NAME" --grep="$TEST_MESSAGE" | wc -l)" -eq 1 ]]
+[[ "$SERVICE_INV_ID" == "$(systemctl show --property=InvocationID "$UNIT_NAME.service")" ]]
+[[ "$TIMER_LAST_TRIGGER" == "$(systemctl show --property=LastTriggerUSec "$UNIT_NAME.timer")" ]]
+
+# Cleanup
+systemctl stop "$UNIT_NAME".{timer,service}
+rm -f "/run/systemd/system/$UNIT_NAME".{timer,service}
+systemctl daemon-reload

--- a/test/TEST-53-TIMER/testsuite.sh
+++ b/test/TEST-53-TIMER/testsuite.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+set -eux
+set -o pipefail
+
+: >/failed
+
+for script in "${0%.sh}".*.sh; do
+    echo "Running $script"
+    "./$script"
+done
+
+touch /testok
+rm /failed

--- a/test/test-execute/exec-systemcallfilter-failing.service
+++ b/test/test-execute/exec-systemcallfilter-failing.service
@@ -4,6 +4,7 @@ Description=Test for SystemCallFilter
 [Service]
 ExecStart=/bin/sh -c 'echo "This should not be seen"'
 Type=oneshot
+LimitCORE=0
 SystemCallFilter=ioperm
 SystemCallFilter=~ioperm
 SystemCallFilter=ioperm

--- a/test/test-execute/exec-systemcallfilter-failing2.service
+++ b/test/test-execute/exec-systemcallfilter-failing2.service
@@ -4,4 +4,5 @@ Description=Test for SystemCallFilter
 [Service]
 ExecStart=/bin/sh -c 'echo "This should not be seen"'
 Type=oneshot
+LimitCORE=0
 SystemCallFilter=~write open execve exit_group close mmap munmap fstat DONOTEXIST

--- a/test/test-functions
+++ b/test/test-functions
@@ -23,7 +23,7 @@ fi
 
 PATH_TO_INIT=$ROOTLIBDIR/systemd
 
-BASICTOOLS="test sh bash setsid loadkeys setfont login sulogin gzip sleep echo mount umount cryptsetup date dmsetup modprobe sed cmp tee rm true false chmod chown ln xargs env mktemp mountpoint useradd userdel timeout jq wc awk diff dirname readlink"
+BASICTOOLS="test sh bash setsid loadkeys setfont login sulogin gzip sleep echo mount umount cryptsetup date dmsetup modprobe sed cmp tee rm true false chmod chown ln xargs env mktemp mountpoint useradd userdel timeout jq wc awk diff dirname readlink cut"
 DEBUGTOOLS="df free ls stty cat ps ln ip route dmesg dhclient mkdir cp ping dhclient strace less grep id tty touch du sort hostname find"
 
 STATEDIR="${BUILD_DIR:-.}/test/$(basename $(dirname $(realpath $0)))"


### PR DESCRIPTION
When a timer is restarted, don't reset the last_trigger field.
This prevents the timer from triggering immediately.

Fixes: #31231
(cherry picked from commit 3fc44a0f68412b649e16f12ff2f97a36c615457d)

Resolves: RHEL-108744

---

Note: this also pulls in changes from #449 to fix a CI fail.

<!-- issue-commentator = {"comment-id":"3346512163"} -->