### PR TITLE
(RHEL-9322) Revert test for a change we don't have in RHEL-8

### DIFF
--- a/test/TEST-19-DELEGATE/testsuite.sh
+++ b/test/TEST-19-DELEGATE/testsuite.sh
@@ -21,27 +21,10 @@ if grep -q cgroup2 /proc/filesystems ; then
                     -w /sys/fs/cgroup/system.slice/test0.service/cgroup.subtree_control
 
         systemd-run --wait --unit=test1.service -p "DynamicUser=1" -p "Delegate=memory pids" \
-                    grep -q memory /sys/fs/cgroup/system.slice/test1.service/cgroup.controllers
+                    grep memory /sys/fs/cgroup/system.slice/test1.service/cgroup.controllers
 
         systemd-run --wait --unit=test2.service -p "DynamicUser=1" -p "Delegate=memory pids" \
-                    grep -q pids /sys/fs/cgroup/system.slice/test2.service/cgroup.controllers
-
-        # "io" is not among the controllers enabled by default for all units, verify that
-        grep -qv io /sys/fs/cgroup/system.slice/cgroup.controllers
-
-        # Run a service with "io" enabled, and verify it works
-        systemd-run --wait --unit=test3.service -p "IOAccounting=yes" -p "Slice=system-foo-bar-baz.slice"  \
-                    grep -q io /sys/fs/cgroup/system.slice/system-foo.slice/system-foo-bar.slice/system-foo-bar-baz.slice/test3.service/cgroup.controllers
-
-        # We want to check if "io" is removed again from the controllers
-        # list. However, PID 1 (rightfully) does this asynchronously. In order
-        # to force synchronization on this, let's start a short-lived service
-        # which requires PID 1 to refresh the cgroup tree, so that we can
-        # verify that this all works.
-        systemd-run --wait --unit=test4.service true
-
-        # And now check again, "io" should have vanished
-        grep -qv io /sys/fs/cgroup/system.slice/cgroup.controllers
+                    grep pids /sys/fs/cgroup/system.slice/test2.service/cgroup.controllers
 
         # Check that unprivileged delegation works for scopes
         test_scope_unpriv_delegation


### PR DESCRIPTION
Revert "test: extend testcase to ensure controller membership doesn't regress"

This reverts commit a3ce5bf1ff531f29c329b3298f3ef69d99e3cbed.

Related: RHEL-9322

<!-- issue-commentator = {"comment-id":"3359770641"} -->