### PR TITLE
(RHEL-133458) encountering ordering cycle triggers segmentation fault

### DIFF
--- a/.github/workflows/gather-metadata.yml
+++ b/.github/workflows/gather-metadata.yml
@@ -22,7 +22,7 @@ jobs:
         uses: redhat-plumbers-in-action/gather-pull-request-metadata@v1
 
       - name: Upload artifact with gathered metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-metadata
           path: ${{ steps.Metadata.outputs.metadata-file }}

--- a/.github/workflows/unit_tests.sh
+++ b/.github/workflows/unit_tests.sh
@@ -137,6 +137,9 @@ for phase in "${PHASES[@]}"; do
 
             # Beautiful workaround for Fedora's version of Docker
             sleep 1
+            # FIXME?: Point C8S repos to the Vault, since C8S is EOL
+            $DOCKER_EXEC bash -xec "sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*"
+            $DOCKER_EXEC bash -xec "sed -i 's|#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
             $DOCKER_EXEC dnf makecache
             # Install and enable EPEL
             $DOCKER_EXEC dnf -q -y install epel-release dnf-utils "${ADDITIONAL_DEPS[@]}"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -341,6 +341,9 @@ static char* merge_unit_ids(const char* unit_log_field, char **pairs) {
                 size += next + 1;
         }
 
+        if (!ans)
+                return strdup("");
+
         return TAKE_PTR(ans);
 }
 

--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -395,7 +395,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                                    j->unit->id,
                                    unit_id == array ? "ordering cycle" : "dependency",
                                    *unit_id, *job_type,
-                                   unit_ids);
+                                   "%s", unit_ids);
 
                 if (delete) {
                         const char *status;
@@ -404,7 +404,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                                    "MESSAGE=%s: Job %s/%s deleted to break ordering cycle starting with %s/%s",
                                    j->unit->id, delete->unit->id, job_type_to_string(delete->type),
                                    j->unit->id, job_type_to_string(j->type),
-                                   unit_ids);
+                                   "%s", unit_ids);
 
                         if (log_get_show_color())
                                 status = ANSI_HIGHLIGHT_RED " SKIP " ANSI_NORMAL;
@@ -420,7 +420,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                 log_struct(LOG_ERR,
                            "MESSAGE=%s: Unable to break cycle starting with %s/%s",
                            j->unit->id, j->unit->id, job_type_to_string(j->type),
-                           unit_ids);
+                           "%s", unit_ids);
 
                 return sd_bus_error_setf(e, BUS_ERROR_TRANSACTION_ORDER_IS_CYCLIC,
                                          "Transaction order is cyclic. See system logs for details.");

--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -6,6 +6,7 @@
 #include "alloc-util.h"
 #include "bus-common-errors.h"
 #include "bus-error.h"
+#include "string-util.h"
 #include "terminal-util.h"
 #include "transaction.h"
 #include "dbus-unit.h"
@@ -402,7 +403,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                                    j->unit->id,
                                    unit_id == array ? "ordering cycle" : "dependency",
                                    *unit_id, *job_type,
-                                   "%s", unit_ids);
+                                   "%s", strna(unit_ids));
 
                 if (delete) {
                         const char *status;
@@ -411,7 +412,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                                    "MESSAGE=%s: Job %s/%s deleted to break ordering cycle starting with %s/%s",
                                    j->unit->id, delete->unit->id, job_type_to_string(delete->type),
                                    j->unit->id, job_type_to_string(j->type),
-                                   "%s", unit_ids);
+                                   "%s", strna(unit_ids));
 
                         if (log_get_show_color())
                                 status = ANSI_HIGHLIGHT_RED " SKIP " ANSI_NORMAL;
@@ -427,7 +428,7 @@ static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsi
                 log_struct(LOG_ERR,
                            "MESSAGE=%s: Unable to break cycle starting with %s/%s",
                            j->unit->id, j->unit->id, job_type_to_string(j->type),
-                           "%s", unit_ids);
+                           "%s", strna(unit_ids));
 
                 return sd_bus_error_setf(e, BUS_ERROR_TRANSACTION_ORDER_IS_CYCLIC,
                                          "Transaction order is cyclic. See system logs for details.");

--- a/src/core/transaction.c
+++ b/src/core/transaction.c
@@ -322,22 +322,26 @@ _pure_ static bool unit_matters_to_anchor(Unit *u, Job *j) {
 }
 
 static char* merge_unit_ids(const char* unit_log_field, char **pairs) {
-        char **unit_id, **job_type, *ans = NULL;
-        size_t alloc = 0, size = 0, next;
+        _cleanup_free_ char *ans = NULL;
+        char **unit_id, **job_type;
+        size_t alloc = 0, size = 0;
 
         STRV_FOREACH_PAIR(unit_id, job_type, pairs) {
+                size_t next;
+
+                if (size > 0)
+                        ans[size - 1] = '\n';
+
                 next = strlen(unit_log_field) + strlen(*unit_id);
                 if (!GREEDY_REALLOC(ans, alloc, size + next + 1)) {
-                        return mfree(ans);
+                        return NULL;
                 }
 
                 sprintf(ans + size, "%s%s", unit_log_field, *unit_id);
-                if (*(unit_id+1))
-                        ans[size + next] =  '\n';
                 size += next + 1;
         }
 
-        return ans;
+        return TAKE_PTR(ans);
 }
 
 static int transaction_verify_order_one(Transaction *tr, Job *j, Job *from, unsigned generation, sd_bus_error *e) {

--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -1408,30 +1408,29 @@ static int bus_manager_log_shutdown(
         assert(unit_name);
 
         if (streq(unit_name, SPECIAL_POWEROFF_TARGET)) {
-                p = "MESSAGE=System is powering down";
+                p = "System is powering down";
                 q = "SHUTDOWN=power-off";
         } else if (streq(unit_name, SPECIAL_REBOOT_TARGET)) {
-                p = "MESSAGE=System is rebooting";
+                p = "System is rebooting";
                 q = "SHUTDOWN=reboot";
         } else if (streq(unit_name, SPECIAL_HALT_TARGET)) {
-                p = "MESSAGE=System is halting";
+                p = "System is halting";
                 q = "SHUTDOWN=halt";
         } else if (streq(unit_name, SPECIAL_KEXEC_TARGET)) {
-                p = "MESSAGE=System is rebooting with kexec";
+                p = "System is rebooting with kexec";
                 q = "SHUTDOWN=kexec";
         } else {
-                p = "MESSAGE=System is shutting down";
+                p = "System is shutting down";
                 q = NULL;
         }
 
-        if (isempty(m->wall_message))
-                p = strjoina(p, ".");
-        else
-                p = strjoina(p, " (", m->wall_message, ").");
-
         return log_struct(LOG_NOTICE,
                           "MESSAGE_ID=" SD_MESSAGE_SHUTDOWN_STR,
-                          p,
+                          LOG_MESSAGE("%s%s%s%s.",
+                                      p,
+                                      m->wall_message ? " (" : "",
+                                      strempty(m->wall_message),
+                                      m->wall_message ? ")" : ""),
                           q);
 }
 

--- a/src/test/test-execute.c
+++ b/src/test/test-execute.c
@@ -30,6 +30,12 @@
 
 typedef void (*test_function_t)(Manager *m);
 
+static int cld_dumped_to_killed(int code) {
+        /* Depending on the system, seccomp version, … some signals might result in dumping, others in plain
+         * killing. Let's ignore the difference here, and map both cases to CLD_KILLED */
+        return code == CLD_DUMPED ? CLD_KILLED : code;
+}
+
 static void wait_for_service_finish(Manager *m, Unit *unit) {
         Service *service = NULL;
         usec_t ts;
@@ -73,7 +79,7 @@ static void check_main_result(const char *func, Manager *m, Unit *unit, int stat
                           service->main_exec_status.status, status_expected);
                 abort();
         }
-        if (service->main_exec_status.code != code_expected) {
+        if (cld_dumped_to_killed(service->main_exec_status.code) != cld_dumped_to_killed(code_expected)) {
                 log_error("%s: %s: exit code %d, expected %d",
                           func, unit->id,
                           service->main_exec_status.code, code_expected);

--- a/test/test-execute/exec-systemcallfilter-failing.service
+++ b/test/test-execute/exec-systemcallfilter-failing.service
@@ -4,6 +4,7 @@ Description=Test for SystemCallFilter
 [Service]
 ExecStart=/bin/sh -c 'echo "This should not be seen"'
 Type=oneshot
+LimitCORE=0
 SystemCallFilter=ioperm
 SystemCallFilter=~ioperm
 SystemCallFilter=ioperm

--- a/test/test-execute/exec-systemcallfilter-failing2.service
+++ b/test/test-execute/exec-systemcallfilter-failing2.service
@@ -4,4 +4,5 @@ Description=Test for SystemCallFilter
 [Service]
 ExecStart=/bin/sh -c 'echo "This should not be seen"'
 Type=oneshot
+LimitCORE=0
 SystemCallFilter=~write open execve exit_group close mmap munmap fstat DONOTEXIST


### PR DESCRIPTION
Backport RHEL-8.10 RHEL-132317 first [PR](https://github.com/redhat-plumbers/systemd-rhel8/pull/456):
The generated string may include %, which will confuse both the xprintf call, and the VA_FORMAT_ADVANCE macro.

Pass the generated string as an argument to a "%s" format string instead.

(cherry picked from commit https://github.com/redhat-plumbers/systemd-rhel8/commit/7325a2b2d15af09a9389723d6153050130c0bd36)

Resolves: RHEL-133458

---
Backport RHEL-8.10 RHEL-132317 second [PR](https://github.com/redhat-plumbers/systemd-rhel8/pull/458):
This is trivially exploitable (in the sense of causing a crash from SEGV) e.g. by 'shutdown now "Message %s %s %n"'. The message is settable through polkit, but is limited to auth_admin:
```
<action id="org.freedesktop.login1.set-wall-message">
         <description gettext-domain="systemd">Set a wall message</description>
         <message gettext-domain="systemd">Authentication is required to set a wall message</message>
         <defaults>
                <allow_any>auth_admin_keep</allow_any>
                <allow_inactive>auth_admin_keep</allow_inactive>
                <allow_active>auth_admin_keep</allow_active>
        </defaults>
</action>
```
Bug introduced in https://github.com/redhat-plumbers/systemd-rhel8/commit/9ef15026c0e7e6600372056c43442c99ec53746e ('logind/systemctl: introduce SetWallMessage and --message', 2015-09-15).

(cherry picked from commit https://github.com/redhat-plumbers/systemd-rhel8/commit/0cb09bcb825ab86ba4ca70be4e6322eaf9baee95)

Related: RHEL-133458

<!-- issue-commentator = {"comment-id":"3730269452"} -->

---
Preemptively backport GH Action CI fixes. May need additional backports.