### PR TITLE
(RHEL-138710) core: only activate transaction that contain useful jobs

### DIFF
--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -1810,6 +1810,11 @@ int manager_propagate_reload(Manager *m, Unit *unit, JobMode mode, sd_bus_error 
         /* Failure in adding individual dependencies is ignored, so this always succeeds. */
         transaction_add_propagate_reload_jobs(tr, unit, tr->anchor_job, mode == JOB_IGNORE_DEPENDENCIES, e);
 
+        /* Only activate the transaction if it contains jobs other than NOP anchor.
+         * Short-circuiting here avoids unnecessary processing, such as emitting D-Bus signals. */
+        if (hashmap_size(tr->jobs) <= 1)
+                return 0;
+
         r = transaction_activate(tr, m, mode, NULL, e);
         if (r < 0)
                 goto tr_abort;


### PR DESCRIPTION
If no real jobs were added to the transaction, do not activate it. The JOB_NOP anchor does not perform any useful work and activating such transaction only wastes resources.

Fixes #9751

<!-- issue-commentator = {"comment-id":"3776592736"} -->