### PR TITLE
(RHEL-152085) core: validate input cgroup path more prudently

### DIFF
--- a/src/core/dbus-manager.c
+++ b/src/core/dbus-manager.c
@@ -456,6 +456,12 @@ static int method_get_unit_by_control_group(sd_bus_message *message, void *userd
         if (r < 0)
                 return r;
 
+        if (!path_is_absolute(cgroup))
+                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not absolute: %s", cgroup);
+
+        if (!path_is_normalized(cgroup))
+                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not normalized: %s", cgroup);
+
         u = manager_get_unit_by_cgroup(m, cgroup);
         if (!u)
                 return sd_bus_error_setf(error, BUS_ERROR_NO_SUCH_UNIT, "Control group '%s' is not valid or not managed by this instance", cgroup);


### PR DESCRIPTION
(cherry picked from commit efa6ba2ab625aaa160ac435a09e6482fc63bdbe8)

Resolves: RHEL-152085

<!-- issue-commentator = {"comment-id":"4037138758"} -->