### PR TITLE
(RHEL-163868) Add some hardening to config file parser in nspawn

### DIFF
--- a/src/nspawn/nspawn-mount.c
+++ b/src/nspawn/nspawn-mount.c
@@ -1410,7 +1410,9 @@ int pivot_root_parse(char **pivot_root_new, char **pivot_root_old, const char *s
 
         if (!path_is_absolute(root_new))
                 return -EINVAL;
-        if (root_old && !path_is_absolute(root_old))
+        if (!path_is_normalized(root_new))
+                return -EINVAL;
+        if (root_old && (!path_is_absolute(root_old) || !path_is_normalized(root_old)))
                 return -EINVAL;
 
         free_and_replace(*pivot_root_new, root_new);


### PR DESCRIPTION
Originally reported on yeswehack.com as:
YWH-PGM9780-116

Follow-up for b53ede699cdc5233041a22591f18863fb3fe2672

(cherry picked from commit 7b85f5498a958e5bb660c703b8f4a71cceed3373)

Resolves: RHEL-163868

<!-- issue-commentator = {"comment-id":"4214926982"} -->