### PR TITLE
(RHEL-163874) Add some hardening around attr. handling to various udev `*_id` tools

### DIFF
--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -25,6 +25,7 @@
 #include "scsi_id.h"
 #include "string-util.h"
 #include "udev-util.h"
+#include "utf8.h"
 
 static const struct option options[] = {
         { "device",             required_argument, NULL, 'd' },
@@ -532,8 +533,8 @@ static int scsi_id(struct udev *udev, char *maj_min_dev)
                 }
                 if (dev_scsi.tgpt_group[0] != '\0')
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
-                if (dev_scsi.unit_serial_number[0] != '\0')
-                        printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
+                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                        printf("ID_SCSI_SERIAL=%s\n", serial_str);
                 goto out;
         }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -534,7 +534,7 @@ static int scsi_id(struct udev *udev, char *maj_min_dev)
                 if (dev_scsi.tgpt_group[0] != '\0')
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
                 if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
-                        printf("ID_SCSI_SERIAL=%s\n", serial_str);
+                        printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
                 goto out;
         }
 

--- a/src/udev/scsi_id/scsi_id.c
+++ b/src/udev/scsi_id/scsi_id.c
@@ -479,6 +479,10 @@ static int set_inq_values(struct udev *udev, struct scsi_id_device *dev_scsi, co
         return 0;
 }
 
+static bool scsi_string_is_valid(const char *s) {
+        return !isempty(s) && utf8_is_valid(s) && !string_has_cc(s, /* ok= */ NULL);
+}
+
 /*
  * scsi_id: try to get an id, if one is found, printf it to stdout.
  * returns a value passed to exit() - 0 if printed an id, else 1.
@@ -523,17 +527,17 @@ static int scsi_id(struct udev *udev, char *maj_min_dev)
                         util_replace_chars(serial_str, NULL);
                         printf("ID_SERIAL_SHORT=%s\n", serial_str);
                 }
-                if (dev_scsi.wwn[0] != '\0') {
+                if (scsi_string_is_valid(dev_scsi.wwn)) {
                         printf("ID_WWN=0x%s\n", dev_scsi.wwn);
-                        if (dev_scsi.wwn_vendor_extension[0] != '\0') {
+                        if (scsi_string_is_valid(dev_scsi.wwn_vendor_extension)) {
                                 printf("ID_WWN_VENDOR_EXTENSION=0x%s\n", dev_scsi.wwn_vendor_extension);
                                 printf("ID_WWN_WITH_EXTENSION=0x%s%s\n", dev_scsi.wwn, dev_scsi.wwn_vendor_extension);
                         } else
                                 printf("ID_WWN_WITH_EXTENSION=0x%s\n", dev_scsi.wwn);
                 }
-                if (dev_scsi.tgpt_group[0] != '\0')
+                if (scsi_string_is_valid(dev_scsi.tgpt_group))
                         printf("ID_TARGET_PORT=%s\n", dev_scsi.tgpt_group);
-                if (dev_scsi.unit_serial_number[0] != '\0' && utf8_is_valid(dev_scsi.unit_serial_number) && !string_has_cc(dev_scsi.unit_serial_number, /* ok= */ NULL))
+                if (scsi_string_is_valid(dev_scsi.unit_serial_number))
                         printf("ID_SCSI_SERIAL=%s\n", dev_scsi.unit_serial_number);
                 goto out;
         }

--- a/src/udev/udev-builtin-net_id.c
+++ b/src/udev/udev-builtin-net_id.c
@@ -103,6 +103,7 @@
 #include "string-util.h"
 #include "udev.h"
 #include "udev-util.h"
+#include "utf8.h"
 
 #define ONBOARD_14BIT_INDEX_MAX ((1U << 14) - 1)
 #define ONBOARD_16BIT_INDEX_MAX ((1U << 16) - 1)
@@ -374,6 +375,10 @@ static int dev_pci_onboard(struct udev_device *dev, struct netnames *names) {
 
         /* kernel provided front panel port name for multiple port PCI device */
         port_name = udev_device_get_sysattr_value(dev, "phys_port_name");
+        if (port_name && (!utf8_is_valid(port_name) || string_has_cc(port_name, /* ok= */ NULL))) {
+                log_debug("Invalid phys_port_name");
+                return -EINVAL;
+        }
 
         s = names->pci_onboard;
         l = sizeof(names->pci_onboard);
@@ -464,6 +469,10 @@ static int dev_pci_slot(struct udev_device *dev, struct netnames *names) {
 
         /* kernel provided front panel port name for multiple port PCI device */
         port_name = udev_device_get_sysattr_value(dev, "phys_port_name");
+        if (port_name && (!utf8_is_valid(port_name) || string_has_cc(port_name, /* ok= */ NULL))) {
+                log_debug("Invalid phys_port_name");
+                return -EINVAL;
+        }
 
         /* compose a name based on the raw kernel's PCI bus, slot numbers */
         s = names->pci_path;

--- a/src/udev/v4l_id/v4l_id.c
+++ b/src/udev/v4l_id/v4l_id.c
@@ -27,6 +27,8 @@
 #include <linux/videodev2.h>
 
 #include "fd-util.h"
+#include "string-util.h"
+#include "utf8.h"
 #include "util.h"
 
 int main(int argc, char *argv[]) {
@@ -65,7 +67,8 @@ int main(int argc, char *argv[]) {
 
         if (ioctl(fd, VIDIOC_QUERYCAP, &v2cap) == 0) {
                 printf("ID_V4L_VERSION=2\n");
-                printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
+                if (utf8_is_valid((char *)v2cap.card) && !string_has_cc((char *)v2cap.card, /* ok= */ NULL))
+                        printf("ID_V4L_PRODUCT=%s\n", v2cap.card);
                 printf("ID_V4L_CAPABILITIES=:");
                 if ((v2cap.capabilities & V4L2_CAP_VIDEO_CAPTURE) > 0 ||
                     (v2cap.capabilities & V4L2_CAP_VIDEO_CAPTURE_MPLANE) > 0)


### PR DESCRIPTION
Resolves: RHEL-163874

<!-- issue-commentator = {"comment-id":"4223816381"} -->