### PR TITLE
(RHEL-85520) user-sessions: do not remove /etc/nologin

### DIFF
--- a/src/basic/fileio-label.c
+++ b/src/basic/fileio-label.c
@@ -55,9 +55,15 @@ int fopen_temporary_label(const char *target,
 int create_shutdown_run_nologin_or_warn(void) {
         int r;
 
-        /* This is used twice: once in systemd-user-sessions.service, in order to block logins when we actually go
-         * down, and once in systemd-logind.service when shutdowns are scheduled, and logins are to be turned off a bit
-         * in advance. We use the same wording of the message in both cases. */
+        /* This is used twice: once in systemd-user-sessions.service, in order to block logins when we
+         * actually go down, and once in systemd-logind.service when shutdowns are scheduled, and logins are
+         * to be turned off a bit in advance. We use the same wording of the message in both cases.
+         *
+         * Traditionally, there was only /etc/nologin, and we managed that. Then, in PAM 1.1
+         * support for /run/nologin was added as alternative
+         * (https://github.com/linux-pam/linux-pam/commit/e9e593f6ddeaf975b7fe8446d184e6bc387d450b).
+         * 13 years later we stopped managing /etc/nologin, leaving it for the administrator to manage.
+         */
 
         r = write_string_file_atomic_label("/run/nologin",
                                            "System is going down. Unprivileged users are not permitted to log in anymore. "

--- a/src/user-sessions/user-sessions.c
+++ b/src/user-sessions/user-sessions.c
@@ -12,7 +12,7 @@
 #include "util.h"
 
 int main(int argc, char*argv[]) {
-        int r, k;
+        int r;
 
         if (argc != 2) {
                 log_error("This program requires one argument.");
@@ -27,12 +27,9 @@ int main(int argc, char*argv[]) {
 
         mac_selinux_init();
 
+        /* We only touch /run/nologin. See create_shutdown_run_nologin_or_warn() for details. */
         if (streq(argv[1], "start")) {
                 r = unlink_or_warn("/run/nologin");
-                k = unlink_or_warn("/etc/nologin");
-                if (k < 0 && r >= 0)
-                        r = k;
-
         } else if (streq(argv[1], "stop"))
                 r = create_shutdown_run_nologin_or_warn();
         else {


### PR DESCRIPTION
pam_nologin looks for /etc/nologin and /run/nologin. user-sessions creates (and removes) /run/nologin, but also removes /etc/nologin. (This behaviour is unchanged since the introduction of the binary in e92787416c691c3f34f47349e5eae3fa68eae856.)

By not removing pam_nologin we fully drop compatibility with PAM < 1.1. This has the advantage that now /etc/nologin can be used by administrator to disable user logins, e.g. for extended maintanance. We already specified PAM >= 1.1.2 as dependency, so this was already covered.

The makes the code match the man page.

Fixes #26965.

(cherry picked from commit a78413baae0e999384b535d327203ebf417b1e24)

Resolves: RHEL-85520

<!-- issue-commentator = {"comment-id":"5044988556"} -->