### PR TITLE
(RHEL-219224) mount: regenerate all deps whenever a mount's parameters  changes

### DIFF
--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1425,6 +1425,32 @@ static int mount_dispatch_timer(sd_event_source *source, usec_t usec, void *user
         return 0;
 }
 
+static int update_parameters_proc_self_mount_info(
+                Mount *m,
+                const char *what,
+                const char *options,
+                const char *fstype) {
+
+        MountParameters *p;
+        int r, q, w;
+
+        p = &m->parameters_proc_self_mountinfo;
+
+        r = free_and_strdup(&p->what, what);
+        if (r < 0)
+                return r;
+
+        q = free_and_strdup(&p->options, options);
+        if (q < 0)
+                return q;
+
+        w = free_and_strdup(&p->fstype, fstype);
+        if (w < 0)
+                return w;
+
+        return r > 0 || q > 0 || w > 0;
+}
+
 typedef struct {
         bool is_mounted;
         bool just_mounted;
@@ -1439,7 +1465,6 @@ static int mount_setup_new_unit(
                 const char *fstype,
                 MountSetupFlags *flags) {
 
-        MountParameters *p;
         int r;
 
         assert(u);
@@ -1452,16 +1477,16 @@ static int mount_setup_new_unit(
 
         /* Make sure to initialize those fields before mount_is_extrinsic(). */
         MOUNT(u)->from_proc_self_mountinfo = true;
-        p = &MOUNT(u)->parameters_proc_self_mountinfo;
 
-        p->what = strdup(what);
-        p->options = strdup(options);
-        p->fstype = strdup(fstype);
-        if (!p->what || !p->options || !p->fstype)
-                return -ENOMEM;
+        r = update_parameters_proc_self_mount_info(MOUNT(u), what, options, fstype);
+        if (r < 0)
+                return r;
 
         if (!mount_is_extrinsic(MOUNT(u))) {
+                MountParameters *p;
                 const char *target;
+
+                p = &MOUNT(u)->parameters_proc_self_mountinfo;
 
                 target = mount_is_network(p) ? SPECIAL_REMOTE_FS_TARGET : SPECIAL_LOCAL_FS_TARGET;
                 r = unit_add_dependency_by_name(u, UNIT_BEFORE, target, NULL, true, UNIT_DEPENDENCY_MOUNTINFO_IMPLICIT);
@@ -1493,9 +1518,9 @@ static int mount_setup_existing_unit(
                 const char *fstype,
                 MountSetupFlags *flags) {
 
-        MountParameters *p;
         bool load_extras = false;
-        int r1, r2, r3;
+        MountParameters *p;
+        int r;
 
         assert(u);
         assert(flags);
@@ -1506,20 +1531,17 @@ static int mount_setup_existing_unit(
                         return -ENOMEM;
         }
 
-        /* Make sure to initialize those fields before mount_is_extrinsic(). */
-        p = &MOUNT(u)->parameters_proc_self_mountinfo;
+        r = update_parameters_proc_self_mount_info(MOUNT(u), what, options, fstype);
+        if (r < 0)
+                return r;
 
-        r1 = free_and_strdup(&p->what, what);
-        r2 = free_and_strdup(&p->options, options);
-        r3 = free_and_strdup(&p->fstype, fstype);
-        if (r1 < 0 || r2 < 0 || r3 < 0)
-                return -ENOMEM;
-
-        flags->just_changed = r1 > 0 || r2 > 0 || r3 > 0;
+        flags->just_changed = r > 0;
         flags->is_mounted = true;
         flags->just_mounted = !MOUNT(u)->from_proc_self_mountinfo || MOUNT(u)->just_mounted;
 
         MOUNT(u)->from_proc_self_mountinfo = true;
+
+        p = &MOUNT(u)->parameters_proc_self_mountinfo;
 
         if (!mount_is_extrinsic(MOUNT(u)) && mount_is_network(p)) {
                 /* _netdev option may have shown up late, or on a

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1872,7 +1872,7 @@ static int drain_libmount(Manager *m) {
 }
 
 static int mount_process_proc_self_mountinfo(Manager *m) {
-        _cleanup_set_free_ Set *around = NULL, *gone = NULL;
+        _cleanup_set_free_free_ Set *around = NULL, *gone = NULL;
         const char *what;
         Iterator i;
         Unit *u;
@@ -1912,7 +1912,7 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
 
                                 /* Remember that this device might just have disappeared */
                                 if (set_ensure_allocated(&gone, &path_hash_ops) < 0 ||
-                                    set_put(gone, mount->parameters_proc_self_mountinfo.what) < 0)
+                                    set_put_strdup(gone, mount->parameters_proc_self_mountinfo.what) < 0)
                                         log_oom(); /* we don't care too much about OOM here... */
                         }
 
@@ -1965,9 +1965,10 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                 if (mount_is_mounted(mount) &&
                     mount->from_proc_self_mountinfo &&
                     mount->parameters_proc_self_mountinfo.what) {
+                        /* Track devices currently used */
 
                         if (set_ensure_allocated(&around, &path_hash_ops) < 0 ||
-                            set_put(around, mount->parameters_proc_self_mountinfo.what) < 0)
+                            set_put_strdup(around, mount->parameters_proc_self_mountinfo.what) < 0)
                                 log_oom();
                 }
 

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -357,7 +357,8 @@ static int mount_add_device_dependencies(Mount *m) {
          * automatically stopped when the device disappears suddenly. */
         dep = mount_is_bound_to_device(m) ? UNIT_BINDS_TO : UNIT_REQUIRES;
 
-        mask = m->from_fragment ? UNIT_DEPENDENCY_FILE : UNIT_DEPENDENCY_MOUNTINFO_IMPLICIT;
+        /* We always use 'what' from /proc/self/mountinfo if mounted */
+        mask = m->from_proc_self_mountinfo ? UNIT_DEPENDENCY_MOUNTINFO_IMPLICIT : UNIT_DEPENDENCY_FILE;
 
         r = unit_add_node_dependency(UNIT(m), p->what, device_wants_mount, dep, mask);
         if (r < 0)
@@ -827,6 +828,9 @@ static void mount_enter_dead(Mount *m, MountResult f) {
         unit_unref_uid_gid(UNIT(m), true);
 
         dynamic_creds_destroy(&m->dynamic_creds);
+
+        /* Any dependencies based on /proc/self/mountinfo are now stale */
+        unit_remove_dependencies(UNIT(m), UNIT_DEPENDENCY_MOUNTINFO_IMPLICIT);
 }
 
 static void mount_enter_mounted(Mount *m, MountResult f) {
@@ -1917,6 +1921,7 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
                         }
 
                         mount->from_proc_self_mountinfo = false;
+                        assert_se(update_parameters_proc_self_mount_info(mount, NULL, NULL, NULL) >= 0);
 
                         switch (mount->state) {
 

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -1560,16 +1560,21 @@ static int mount_setup_existing_unit(
                 u->load_state = UNIT_LOADED;
                 u->load_error = 0;
 
-                /* Load in the extras later on, after we
-                 * finished initialization of the unit */
-
-                /* FIXME: since we're going to load the unit later on, why setting load_extras=true ? */
-                load_extras = true;
                 flags->just_changed = true;
         }
 
         if (load_extras)
                 return mount_add_non_exec_dependencies(MOUNT(u));
+        if (flags->just_changed) {
+                /* If things changed, then make sure that all deps are regenerated. Let's
+                 * first remove all automatic deps, and then add in the new ones. */
+
+                unit_remove_dependencies(u, UNIT_DEPENDENCY_MOUNTINFO_IMPLICIT);
+
+                r = mount_add_extras(MOUNT(u));
+                if (r < 0)
+                        return r;
+        }
 
         return 0;
 }


### PR DESCRIPTION
Whenever we notice a change on an existing /proc/self/mountinfo line,
let's update the deps generated from it. For that, let's flush out the
old deps generated this way, and add in the new ones.

This takes benefit of the fact that today (unlike a comment this patch
removes says) we can remove deps in a somewhat reasonable way.

(cherry picked from commit a37422045fbb68ad68f734e5dc00e0a5b1759773)

Resolves: RHEL-219224

<!-- issue-commentator = {"comment-id":"5278864193"} -->